### PR TITLE
acme: Don't restrict challenge types

### DIFF
--- a/crates/common/src/listener/acme/directory.rs
+++ b/crates/common/src/listener/acme/directory.rs
@@ -244,6 +244,8 @@ pub enum ChallengeType {
     Dns01,
     #[serde(rename = "tls-alpn-01")]
     TlsAlpn01,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize)]
@@ -366,6 +368,7 @@ impl ChallengeType {
             Self::Http01 => "http-01",
             Self::Dns01 => "dns-01",
             Self::TlsAlpn01 => "tls-alpn-01",
+            Self::Unknown => "unknown",
         }
     }
 }


### PR DESCRIPTION
When testing my Stalwart deployment with Pebble[1], I got the following ACME error:

```
ACME error (acme.error) {
  reason = "unknown variant `dns-account-01`, expected one of `http-01`, `dns-01`, `tls-alpn-01` at line 15 column 33",
  details = JSON deserialization failed
}
```

In RFC 8555 section 8[2], the validation challenges are meant to be extensible:

> The identifier validation challenges described in this section all
> relate to validation of domain names. If ACME is extended in the
> future to support other types of identifiers, there will need to be
> new challenge types, and they will need to specify which types of
> identifier they apply to.

The mentioned error refers to the following draft:

https://datatracker.ietf.org/doc/html/draft-ietf-acme-dns-account-label-01

Pebble already implemented[3] this and while it's IMHO too early to already support this in Stalwart, we should at least make sure that we don't break existing deployments in case ACME CAs one day add more challange types like the above.

[1]: https://github.com/letsencrypt/pebble
[2]: https://datatracker.ietf.org/doc/html/rfc8555#section-8
[3]: https://github.com/letsencrypt/pebble/pull/435