### PR TITLE
store: enable rocksdb/jemalloc feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,26 +3794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jieba-macros"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7656,7 +7636,6 @@ dependencies = [
  "groupware",
  "http 0.12.0",
  "imap",
- "jemallocator",
  "jmap",
  "jmap_proto",
  "managesieve",
@@ -7666,6 +7645,7 @@ dependencies = [
  "smtp",
  "spam-filter",
  "store",
+ "tikv-jemallocator",
  "tokio",
  "trc",
  "utils",
@@ -7941,7 +7921,6 @@ dependencies = [
  "hyper-util",
  "imap",
  "imap_proto",
- "jemallocator",
  "jmap",
  "jmap-client",
  "jmap_proto",
@@ -7970,6 +7949,7 @@ dependencies = [
  "smtp-proto",
  "spam-filter",
  "store",
+ "tikv-jemallocator",
  "tokio",
  "tokio-rustls 0.26.2",
  "trc",
@@ -8024,6 +8004,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4156,6 +4156,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -37,7 +37,7 @@ migration = { path = "../migration" }
 tokio = { version = "1.45", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = "0.5.0"
+tikv-jemallocator = "0.6.0"
 
 [features]
 #default = ["sqlite", "postgres", "mysql", "rocks", "elastic", "s3", "redis", "azure", "nats", "enterprise"]

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -18,7 +18,7 @@ use trc::Collector;
 use utils::wait_for_shutdown;
 
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 utils = { path = "../utils" }
 nlp = { path = "../nlp" }
 trc = { path = "../trc" }
-rocksdb = { version = "0.23", optional = true, features = ["multi-threaded-cf"] }
+rocksdb = { version = "0.23", optional = true, features = ["multi-threaded-cf", "jemalloc"] }
 foundationdb = { version = "0.9.2", features = ["embedded-fdb-include", "fdb-7_3"], optional = true }
 rusqlite = { version = "0.35", features = ["bundled"], optional = true }
 rust-s3 = { version = "0.35", default-features = false, features = ["tokio-rustls-tls", "no-verify-ssl"], optional = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -81,4 +81,4 @@ quick-xml = "0.37.2"
 
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = "0.5.0"
+tikv-jemallocator = "0.6.0"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 #[cfg(test)]
 use trc::Collector;
 


### PR DESCRIPTION
stalwart-mail sets the Rust allocator to jemalloc via the jemallocator crate.
But rocksdb does not properly distinguish between pointers it has allocated itself, and pointers which were passed in and might be registered with a different allocator.

Thus, rocksdb with jemalloc can only work properly when the malloc library is globally overridden (as can be obtained by setting the `unprefixed_malloc_on_supported_platforms` feature of jemalloc-sys, [as rust-rocksdb does](https://github.com/rust-rocksdb/rust-rocksdb/blob/master/librocksdb-sys/Cargo.toml#L37)), but because stalwart-mail never enables the jemalloc feature of the rocksdb crate, this never happens.

Thus, I'm enabling the jemalloc feature of the rocksdb crate, which also required changing to the more maintained tikv-jemallocator to match what rust-rocksdb uses, since we can't have two crates attempting to link jemalloc at the same time.