### PR TITLE
SECURITY_PROCESS.md: fix typo in link to Security Policy

### DIFF
--- a/SECURITY_PROCESS.md
+++ b/SECURITY_PROCESS.md
@@ -24,7 +24,7 @@ Potential impact:
 
 ### Resources
 
-- [Stalwart Security Policy](https://github.com/stalwartlabs/stalwart/blob/main/SECURITY.mdy)
+- [Stalwart Security Policy](https://github.com/stalwartlabs/stalwart/blob/main/SECURITY.md)
 - [CVE Scoring Calculator](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator)
 - [Rust Security Advisory Database](https://rustsec.org/)
 


### PR DESCRIPTION
Hello! Great IRP! I noticed a typo while looking through it, so here's a drive-by commit to fix it :)