### PR TITLE
feat(docker): Add curl to Docker images and optimize package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,15 @@ FROM docker.io/debian:bookworm-slim
 WORKDIR /opt/stalwart
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -yq ca-certificates
+    apt-get install -yq --no-install-recommends \
+      ca-certificates \
+      curl && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 COPY --from=builder /output/stalwart /usr/local/bin
 COPY --from=builder /output/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod -R 755 /usr/local/bin
 CMD ["/usr/local/bin/stalwart"]
 VOLUME [ "/opt/stalwart" ]
-EXPOSE	443 25 110 587 465 143 993 995 4190 8080
+EXPOSE 443 25 110 587 465 143 993 995 4190 8080
 ENTRYPOINT ["/bin/sh", "/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -142,14 +142,18 @@ FROM --platform=$TARGETPLATFORM docker.io/library/debian:bookworm-slim AS gnu
 WORKDIR /opt/stalwart
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -yq ca-certificates tzdata
+    apt-get install -yq --no-install-recommends \
+      ca-certificates \
+      tzdata \
+      curl && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 COPY --from=builder /app/artifact/stalwart /usr/local/bin
 COPY --from=builder /app/artifact/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod -R 755 /usr/local/bin
 CMD ["/usr/local/bin/stalwart"]
 VOLUME [ "/opt/stalwart" ]
-EXPOSE	443 25 110 587 465 143 993 995 4190 8080
+EXPOSE 443 25 110 587 465 143 993 995 4190 8080
 ENTRYPOINT ["/bin/sh", "/usr/local/bin/entrypoint.sh"]
 
 # *****************
@@ -157,12 +161,12 @@ ENTRYPOINT ["/bin/sh", "/usr/local/bin/entrypoint.sh"]
 # *****************
 FROM --platform=$TARGETPLATFORM alpine AS musl
 WORKDIR /opt/stalwart
-RUN apk add --update --no-cache ca-certificates tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache ca-certificates tzdata curl
 COPY --from=builder /app/artifact/stalwart /usr/local/bin
 COPY --from=builder /app/artifact/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod -R 755 /usr/local/bin
 CMD ["/usr/local/bin/stalwart"]
 VOLUME [ "/opt/stalwart" ]
-EXPOSE	443 25 110 587 465 143 993 995 4190 8080
+EXPOSE 443 25 110 587 465 143 993 995 4190 8080
 ENTRYPOINT ["/bin/sh", "/usr/local/bin/entrypoint.sh"]

--- a/resources/docker/Dockerfile.fdb
+++ b/resources/docker/Dockerfile.fdb
@@ -41,7 +41,12 @@ RUN cargo build --manifest-path=crates/main/Cargo.toml --no-default-features --f
 FROM debian:buster-slim AS runtime
 
 COPY --from=builder /app/target/release/stalwart /usr/local/bin/stalwart
-RUN apt-get update -y && apt-get install -yq ca-certificates
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -yq --no-install-recommends \
+      ca-certificates \
+      curl && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 RUN curl -LO https://github.com/apple/foundationdb/releases/download/7.1.0/foundationdb-clients_7.1.0-1_amd64.deb && \
     dpkg -i foundationdb-clients_7.1.0-1_amd64.deb
 RUN useradd stalwart -s /sbin/nologin -M


### PR DESCRIPTION
### Summary

This PR adds `curl` to both the Debian-based and Alpine-based Docker images used in the project. It also optimizes package installation by removing unnecessary package caches, helping reduce the overall image size.

### Changes

- ✅ **Added `curl` to `Dockerfile` (Debian-based)**
  - Installed using `apt install --no-install-recommends` to minimize additional dependencies.
  - Cleaned up APT cache (`/var/lib/apt/lists/*`, `/var/cache/apt/*`) to reduce image size.

- ✅ **Added `curl` to `Dockerfile` (Alpine-based)**
  - Removed the unnecessary `--update` flag.
  - Removed `&& rm -rf /var/cache/apk/*` since `--no-cache` already prevents cache storage.

### Benefits

- `curl` is now available in all images for healthchecks
- Images are slimmer and more secure due to removal of unused package data

### References

- 📄 Discussion: #1410
- 🐛 Issue: #1781