### PR TITLE
Docker: nicer apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ FROM docker.io/debian:bookworm-slim
 WORKDIR /opt/stalwart
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -yq ca-certificates
+    apt-get install -yq --no-install-recommends \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 COPY --from=builder /output/stalwart /usr/local/bin
 COPY --from=builder /output/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -142,7 +142,10 @@ FROM --platform=$TARGETPLATFORM docker.io/library/debian:bookworm-slim AS gnu
 WORKDIR /opt/stalwart
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -yq ca-certificates tzdata
+    apt-get install -yq --no-install-recommends \
+      ca-certificates \
+      tzdata \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 COPY --from=builder /app/artifact/stalwart /usr/local/bin
 COPY --from=builder /app/artifact/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -157,7 +160,8 @@ ENTRYPOINT ["/bin/sh", "/usr/local/bin/entrypoint.sh"]
 # *****************
 FROM --platform=$TARGETPLATFORM alpine AS musl
 WORKDIR /opt/stalwart
-RUN apk add --update --no-cache ca-certificates tzdata && rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache ca-certificates tzdata \
+    && rm -rf /var/cache/apk/*
 COPY --from=builder /app/artifact/stalwart /usr/local/bin
 COPY --from=builder /app/artifact/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/resources/docker/Dockerfile.fdb
+++ b/resources/docker/Dockerfile.fdb
@@ -41,7 +41,11 @@ RUN cargo build --manifest-path=crates/main/Cargo.toml --no-default-features --f
 FROM debian:buster-slim AS runtime
 
 COPY --from=builder /app/target/release/stalwart /usr/local/bin/stalwart
-RUN apt-get update -y && apt-get install -yq ca-certificates
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -yq --no-install-recommends \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 RUN curl -LO https://github.com/apple/foundationdb/releases/download/7.1.0/foundationdb-clients_7.1.0-1_amd64.deb && \
     dpkg -i foundationdb-clients_7.1.0-1_amd64.deb
 RUN useradd stalwart -s /sbin/nologin -M


### PR DESCRIPTION
It has option --no-install-recommends
and does rm -rf /var/lib/apt/lists/* /var/cache/apt/* to get a smaller image.

And a long `apk add` line was spilt in to two physical lines.