### PR TITLE
Curl included in the docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM docker.io/debian:bookworm-slim
 WORKDIR /opt/stalwart
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -yq ca-certificates
+    apt-get install -yq ca-certificates curl
 COPY --from=builder /output/stalwart /usr/local/bin
 COPY --from=builder /output/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -142,7 +142,7 @@ FROM --platform=$TARGETPLATFORM docker.io/library/debian:bookworm-slim AS gnu
 WORKDIR /opt/stalwart
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -yq ca-certificates tzdata
+    apt-get install -yq ca-certificates tzdata curl
 COPY --from=builder /app/artifact/stalwart /usr/local/bin
 COPY --from=builder /app/artifact/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -157,7 +157,7 @@ ENTRYPOINT ["/bin/sh", "/usr/local/bin/entrypoint.sh"]
 # *****************
 FROM --platform=$TARGETPLATFORM alpine AS musl
 WORKDIR /opt/stalwart
-RUN apk add --update --no-cache ca-certificates tzdata && rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache ca-certificates tzdata curl && rm -rf /var/cache/apk/*
 COPY --from=builder /app/artifact/stalwart /usr/local/bin
 COPY --from=builder /app/artifact/stalwart-cli /usr/local/bin
 COPY ./resources/docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/resources/docker/Dockerfile.fdb
+++ b/resources/docker/Dockerfile.fdb
@@ -41,7 +41,7 @@ RUN cargo build --manifest-path=crates/main/Cargo.toml --no-default-features --f
 FROM debian:buster-slim AS runtime
 
 COPY --from=builder /app/target/release/stalwart /usr/local/bin/stalwart
-RUN apt-get update -y && apt-get install -yq ca-certificates
+RUN apt-get update -y && apt-get install -yq ca-certificates curl
 RUN curl -LO https://github.com/apple/foundationdb/releases/download/7.1.0/foundationdb-clients_7.1.0-1_amd64.deb && \
     dpkg -i foundationdb-clients_7.1.0-1_amd64.deb
 RUN useradd stalwart -s /sbin/nologin -M


### PR DESCRIPTION
For making health check possible that docker-compose can do.

Co-authored-by: Hendrik Hüls <hendrik.huels@outlook.de>

Longer version of why:

In a docker-compose file can a health check be defined, like:

```yaml
  services:
    stalwart:
      image: stalwartlabs/stalwart
      healthcheck:
        test: ["CMD", "curl", "--fail", "http://localhost:8080/healthz/ready"]
        interval: 30s
        timeout: 5s
        retries: 3
        start_period: 10s
```

And that needs curl executable in the image.