### PR TITLE
Added meta data for `cargo deb`

### DIFF
--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -67,3 +67,14 @@ enterprise = [ "jmap/enterprise",
                "groupware/enterprise",
                "trc/enterprise",
                "services/enterprise" ]
+
+# Information for `cargo deb`
+[package.metadata.deb]
+# NOTE: Work in progress
+# Status is at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109537
+# and at https://github.com/stalwartlabs/stalwart/discussions/1949
+assets = [
+    # What from here, Destination in Debian package, File permission in .deb
+    ["target/release/stalwart", "usr/bin/", "755"],
+    ["target/release/stalwart-cli", "usr/bin/", "755"],
+]


### PR DESCRIPTION
Now results `cargo deb` in a .deb being build.
The debian package has the binaries stalwart and stalwart-cli.

For what it is worth:
cargo-deb finds out that "stalwart" is the default rust package. That rust package "stalwart-cli" is needed to be build is also something that cargo-deb figures out.
To be able to do `cargo deb` you first have to do `cargo install cargo-deb`