### PR TITLE
Fix CardDAV sync-collection changelog filtering bug

### DIFF
--- a/crates/dav/src/common/propfind.rs
+++ b/crates/dav/src/common/propfind.rs
@@ -1269,7 +1269,10 @@ async fn get(
                         total_changes += document_ids.len() as usize;
                     } else {
                         total_changes += changes.len() as usize;
-                        *document_ids = Some(changes);
+                        // Don't replace None with empty bitmap - preserve full access
+                        if !changes.is_empty() {
+                            *document_ids = Some(changes);
+                        }
                     }
                 }
             } else {
@@ -1292,7 +1295,10 @@ async fn get(
                     total_changes += document_ids.len() as usize;
                 } else {
                     total_changes += changes.len() as usize;
-                    display_containers = Some(changes);
+                    // Don't replace None with empty bitmap - preserve full access
+                    if !changes.is_empty() {
+                        display_containers = Some(changes);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

Fixes #2115

This PR fixes a critical bug in CardDAV sync-collection that was causing empty responses due to incorrect changelog filtering logic.

## Problem

CardDAV sync-collection requests were returning empty responses even when contacts existed. The root cause was in `crates/dav/src/common/propfind.rs` where the code incorrectly replaced `None` document filters with empty `RoaringBitmap`, causing subsequent intersections to return no results.

## Root Cause Analysis

```rust
// WRONG: Always replaces None with empty bitmap
*document_ids = Some(changes);
display_containers = Some(changes);

// This caused problems when changes was empty - it would create an empty bitmap
// that would intersect with any subsequent change set and produce no results
```

## Solution

```rust
// CORRECT: Only replace None when changes exist
if \!changes.is_empty() {
    *document_ids = Some(changes);
}

if \!changes.is_empty() {
    display_containers = Some(changes);
}
```

The fix preserves the original `None` state when there are no changes in the current change set, allowing full access to be maintained instead of creating an empty filter.

## Files Changed

- `crates/dav/src/common/propfind.rs` - Fixed changelog filtering logic on lines ~1272 and ~1295

## Impact

- ✅ CardDAV clients now receive proper sync-collection responses
- ✅ Contacts are returned with their etags when they exist
- ✅ Particularly fixes clients requesting `getetag` + `getcontenttype` without `address-data`
- ✅ Enables proper contact synchronization workflow

## Testing

This fix resolves the core issue that was preventing CardDAV sync-collection from working correctly. Clients can now:
1. Make initial sync-collection request to get contact etags
2. Make follow-up requests for full contact data based on etags
3. Properly synchronize contact collections

## Related Issues

This addresses the changelog filtering bug specifically and is separate from:
- #1608 (Apple Contacts upload stopping) - different root cause
- Client compatibility issues (handled in separate PR)