### PR TITLE
crates/dav/src/request.rs: unused variable request

### DIFF
--- a/crates/dav/src/request.rs
+++ b/crates/dav/src/request.rs
@@ -80,7 +80,7 @@ pub(crate) trait DavRequestDispatcher: Sync + Send {
 impl DavRequestDispatcher for Server {
     async fn dispatch_dav_request(
         &self,
-        request: &HttpRequest,
+        _request: &HttpRequest,
         headers: &RequestHeaders<'_>,
         access_token: Arc<AccessToken>,
         resource: DavResourceName,


### PR DESCRIPTION
warning: unused variable: `request`
  --> crates/dav/src/request.rs:83:9
   |
83 |  request: &HttpRequest,
   |  ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_request`
   |