### PR TITLE
Add riscv64 architecture to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,14 @@ jobs:
             platform: linux/amd64
             suffix: '-alpine'
             build_env: ''
+          - target: riscv64-unknown-linux-gnu
+            platform: linux/riscv64
+            suffix: ''
+            build_env: ''
+          - target: riscv64-unknown-linux-musl
+            platform: linux/riscv64
+            suffix: '-alpine'
+            build_env: ''
           - target: aarch64-unknown-linux-gnu
             platform: linux/arm64
             suffix: ''


### PR DESCRIPTION
Add riscv64 architecture to ci.yml linux build matrix