### PR TITLE
YAML output option for stalwart-cli server list-config

### DIFF
--- a/crates/cli/src/modules/cli.rs
+++ b/crates/cli/src/modules/cli.rs
@@ -452,6 +452,9 @@ pub enum ServerCommands {
     ListConfig {
         /// Prefix to filter configuration entries by
         prefix: Option<String>,
+        /// Output in sorted YAML
+        #[clap(short, long)]
+        yaml: bool,
     },
 
     /// Perform Healthcheck


### PR DESCRIPTION
Rationale: It is useful to have a key-value list in YAML format because it reflects all the database keys and their values well (unlike TOML) and accurately. The API already offers JSON, but YAML is even cleaner, and more readable for multiline values.

Feat: Option to have stalwart-cli server list-config output in sorted YAML.

Justification: Very limited scope, outside of core, small change: add flag -y|--yaml to get stalwart-cli server list-config to output in sorted YAML format to stdout:

- In crates/cli/src/modules/cli.rs add the yaml flag plus short description for help.
- In crates/cli/src/modules/database.rs add 15 lines to sort by key and format the output to YAML.
