### PR TITLE
Add Linode provider (needs updated dns-updater 0.1.6)

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -20,7 +20,7 @@ mail-builder = { version = "0.4" }
 mail-auth = { version = "0.7.1" }
 mail-send = { version = "0.5", default-features = false, features = ["cram-md5", "ring", "tls12"] }
 smtp-proto = { version = "0.2", features = ["rkyv"] }
-dns-update = { version = "0.1.5" }
+dns-update = { version = "0.1.6" }
 calcard = { version = "0.1.3", features = ["rkyv"] }
 ahash = { version = "0.8.2", features = ["serde"] }
 parking_lot = "0.12.1"

--- a/crates/common/src/config/server/tls.rs
+++ b/crates/common/src/config/server/tls.rs
@@ -250,6 +250,20 @@ fn build_dns_updater(config: &mut Config, acme_id: &str) -> Option<DnsUpdater> {
             )
         })
         .ok(),
+        "linode" => DnsUpdater::new_linode(
+            config
+                .value_require(("acme", acme_id, "secret"))?
+                .trim()
+                .to_string(),
+            timeout.into(),
+        )
+        .map_err(|err| {
+            config.new_build_error(
+                ("acme", acme_id, "provider"),
+                format!("Failed to create Linode DNS updater: {err}"),
+            )
+        })
+        .ok(),
         "digitalocean" => DnsUpdater::new_digitalocean(
             config
                 .value_require(("acme", acme_id, "secret"))?


### PR DESCRIPTION
(I thought I'd open this PR incase it helps. Thank you for your work on Stalwart.)

**Do not merge** until https://github.com/stalwartlabs/dns-update/pull/22 goes through AND the new 0.1.6 version of `dns-updater` is pushed to crates.io.

The PR was tested against my local copy of 0.1.6 of dns-update; the only change I made was removing `path = "/anonycos/local/dns-update/"` from line 23 for this PR, which will work again once the new version can be pulled from crates.io.