### PR TITLE
feat: Add sd_notify support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,7 @@ dependencies = [
  "rev_lines",
  "rkyv",
  "rsa",
+ "sd-notify",
  "serde",
  "serde_json",
  "services",
@@ -6948,6 +6949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sd-notify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7718,6 +7728,7 @@ dependencies = [
  "managesieve",
  "migration",
  "pop3",
+ "sd-notify",
  "services",
  "smtp",
  "spam-filter",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -45,6 +45,7 @@ rkyv = { version = "0.8.10", features = ["little_endian"] }
 form-data = { version = "0.6.0", features = ["sync"], default-features = false }
 mime = "0.3.17"
 compact_str = "0.9.0"
+sd-notify = "0.4.5"
 
 [dev-dependencies]
 

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -35,6 +35,7 @@ trc = { path = "../trc" }
 utils = { path = "../utils" }
 migration = { path = "../migration" }
 tokio = { version = "1.47", features = ["full"] }
+sd-notify = "0.4.5"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"


### PR DESCRIPTION
Closes https://github.com/stalwartlabs/stalwart/issues/283

Allows a systemd service to use `Type=notify`, so it's only considered ready once all the listeners are up.
Additionally I also added sd_notify Reloading support, so systemd knows when stalwart is reloading the config due to an API call to the management API.
See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Options and https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#Well-known%20assignments.