### PR TITLE
Add FreeBSD (x86_64, aarch64) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,8 +401,8 @@ jobs:
         include:
           - target: x86_64-unknown-freebsd
             arch: x86_64
-          - target: aarch64-unknown-freebsd
-            arch: aarch64
+          # - target: aarch64-unknown-freebsd
+          #   arch: aarch64
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,59 @@ jobs:
           name: artifact-${{matrix.target}}
           path: artifacts
 
+  freebsd:
+    name: Build / ${{matrix.target}}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-freebsd
+            arch: x86_64
+          - target: aarch64-unknown-freebsd
+            arch: aarch64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Build in FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "15.1"
+          arch: ${{matrix.arch}}
+          usesh: true
+          mem: 14336
+          cpu: 4
+          sync: rsync
+          copyback: true
+          # gmake: required by jemalloc-sys on BSD hosts
+          # llvm: provides libclang for bindgen (librocksdb-sys)
+          # rust: libsqlite3-sys 0.38 uses cfg_select!, stabilized in Rust
+          # 1.95. The default 'quarterly' pkg repo still ships rust 1.94, so
+          # switch to the 'latest' repo (currently 1.96.1). rustup is not an
+          # option here: aarch64-unknown-freebsd has no rustup toolchains yet.
+          prepare: |
+            set -e
+            mkdir -p /usr/local/etc/pkg/repos
+            echo 'FreeBSD: { url: "pkg+https://pkg.freebsd.org/${ABI}/latest", mirror_type: "srv" }' > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update -f
+            pkg install -y rust gmake llvm rocksdb
+            rustc --version
+          run: |
+            set -e
+            export CARGO_TARGET_DIR=/tmp/target
+            export CARGO_TERM_COLOR=always
+            cargo build --release -p stalwart --no-default-features --features "sqlite postgres mysql rocks s3 redis azure nats enterprise"
+            mkdir -p artifacts
+            cp /tmp/target/release/stalwart artifacts/stalwart
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-${{matrix.target}}
+          path: artifacts
+
   release:
     name: Release
     permissions:
@@ -398,7 +451,7 @@ jobs:
       contents: write
       attestations: write
     if: github.event_name == 'push' || inputs.Release
-    needs: [linux, windows, macos]
+    needs: [linux, windows, macos, freebsd]
     runs-on: ubuntu-latest
     steps:
       # Must run before artifacts are downloaded — checkout cleans the workspace.
@@ -484,7 +537,7 @@ jobs:
 
   publish:
     name: Publish release
-    needs: [linux, windows, macos, multiarch, release]
+    needs: [linux, windows, macos, freebsd, multiarch, release]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
@@ -497,7 +550,7 @@ jobs:
 
   cleanup:
     name: Cleanup failed release
-    needs: [linux, windows, macos, multiarch, release]
+    needs: [linux, windows, macos, freebsd, multiarch, release]
     if: failure() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This PR adds FreeBSD builds for x86_64 and aarch64.

Currently the x86_64 build succeeds but aarch64 times out before completion (due to qemu being slow).

Some alternative suggestions to land this:
1. Focus on x86_64 for now and disable aarch64 to keep ball rolling.
2. Use larger github hosted runners, so that CPU count can be increased.
3. Explore self-hosted runners. Unfortunately I don't have access to aarch64 system and seems more brittle.
4. Disable some features for the aarch64 build to make it finish build before timeout (6 hours). Would need some guidance on which features are less popular.

Once we have an official build I'll work on updating install.sh to support FreeBSD with rc.d service script.

Closes https://github.com/stalwartlabs/stalwart/issues/253 
Closes https://github.com/stalwartlabs/stalwart/issues/1736