### PR TITLE
Various FreeBSD improvements

### DIFF
--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -40,7 +40,7 @@ migration = { path = "../migration" }
 tokio = { version = "1.47", features = ["full"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std", "aws_lc_rs", "tls12"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = "0.5.0"
 
 [features]

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -23,10 +23,10 @@ use utils::wait_for_shutdown;
 #[cfg(feature = "dev_mode")]
 pub mod test_data;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 use jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/install.sh
+++ b/install.sh
@@ -495,12 +495,16 @@ load_rc_config \$name
 pidfile="/var/run/stalwart.pid"
 procname="${_bin}"
 command="/usr/sbin/daemon"
-command_args="-f -o \${stalwart_logfile} -p \${pidfile} -u \${stalwart_user} ${_bin} --config=\${stalwart_config}"
+command_args="-f -o \${stalwart_logfile} -p \${pidfile} ${_bin} --config=\${stalwart_config}"
 sig_stop="INT"
 start_precmd="stalwart_precmd"
 
 stalwart_precmd()
 {
+    # rc.subr runs the command as \${stalwart_user} (via su -m), which cannot
+    # create the pidfile in root-owned /var/run — pre-create it here as root
+    install -o "\${stalwart_user}" -g "\${stalwart_user}" -m 0600 /dev/null "\${pidfile}"
+
     # daemon(8) passes its environment through to the service
     if [ -r "\${stalwart_envfile}" ]; then
         set -a

--- a/install.sh
+++ b/install.sh
@@ -486,7 +486,8 @@ desc="Stalwart Server"
 load_rc_config \$name
 
 : \${stalwart_enable:="NO"}
-: \${stalwart_user:="${_user}"}
+: \${stalwart_runas_user:="${_user}"}
+: \${stalwart_runas_group:="${_user}"}
 : \${stalwart_config:="${_config}"}
 : \${stalwart_envfile:="${_env}"}
 : \${stalwart_logfile:="${_log_dir}/stalwart.log"}
@@ -501,20 +502,18 @@ start_precmd="stalwart_precmd"
 
 stalwart_precmd()
 {
-    # rc.subr runs the command as \${stalwart_user} (via su -m), which cannot
-    # create the pidfile in root-owned /var/run — pre-create it here as root
-    install -o "\${stalwart_user}" -g "\${stalwart_user}" -m 0600 /dev/null "\${pidfile}"
-
     # daemon(8) passes its environment through to the service
     if [ -r "\${stalwart_envfile}" ]; then
         set -a
         . "\${stalwart_envfile}"
         set +a
     fi
-    ulimit -n "\${stalwart_fdlimit}"
 
-    # Binding privileged ports (25/443/465/993/...) as a non-root user
-    # requires: sysctl net.inet.ip.portrange.reservedhigh=0
+    # Stalwart binds its listeners as root, then setuid()s to this account
+    export RUN_AS_USER="\${stalwart_runas_user}"
+    export RUN_AS_GROUP="\${stalwart_runas_group}"
+
+    ulimit -n "\${stalwart_fdlimit}"
 }
 
 run_rc_command "\$1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -89,5 +89,5 @@ time = "0.3"
 testcontainers = { version = "0.27", features = ["reusable-containers"] }
 rust-s3 = { version = "0.37", default-features = false, features = ["tokio-rustls-tls"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = "0.5.0"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -6,10 +6,10 @@
 
 #[cfg(test)]
 use ::store::registry::bootstrap::Bootstrap;
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 use jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
The previous install.sh changes did not create /var/run/stalwart.pid properly on FreeBSD.

Also fixes SIGSEGV on FreeBSD due to jemalloc dependency.