### PR TITLE
ci: pin aquasecurity/trivy-action to a full commit SHA

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6.0.1
         
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
### What
Pin `aquasecurity/trivy-action@master` → `c07df6f…` in `trivy.yml` (tag kept in a comment).

### Why
`@master` is a moving ref. This third-party action runs in a job granted `security-events: write` on
the `GITHUB_TOKEN` (used later by `github/codeql-action/upload-sarif`), and `actions/checkout` persists
that token in the workspace that trivy then scans. If the action's `master` were moved (compromise or
an accidental change), the new code would run with that token in scope — the class behind the 2025
`tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>
