### PR TITLE
Fix JMAP: EmailSubmission/set rejects recipients whose domain is a public suffix

### DIFF
--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -422,18 +422,63 @@ pub fn is_valid_domain(domain: &str) -> bool {
         "private",
         "localdomain",
     ];
-    psl::domain(domain.as_bytes()).is_some_and(|d| d.suffix().typ().is_some())
+    has_valid_public_suffix(domain)
         || RESERVED_TLDS.contains(&domain)
         || domain
             .rsplit_once('.')
             .is_some_and(|(_, tld)| RESERVED_TLDS.contains(&tld))
 }
 
+/// Returns `true` if `domain` is backed by a known public suffix.
+///
+/// This accepts both registrable domains (a known public suffix plus at least
+/// one additional label, e.g. `example.com`) and domains that are themselves a
+/// multi-label public suffix (an eTLD). Several eTLDs host real, deliverable
+/// mailboxes directly on the suffix, for example `gov.in`, `nic.in`, `co.in` or
+/// `ac.in`, so rejecting them would refuse valid recipients. Bare top-level
+/// domains (e.g. `com`, `in`) are still rejected as they contain no dot.
+fn has_valid_public_suffix(domain: &str) -> bool {
+    let bytes = domain.as_bytes();
+
+    // Registrable domain: a known public suffix plus at least one more label.
+    if psl::domain(bytes).is_some_and(|d| d.suffix().typ().is_some()) {
+        return true;
+    }
+
+    // The domain itself is a multi-label public suffix (eTLD) that may host
+    // mailboxes directly, e.g. `gov.in`. Exclude bare TLDs by requiring a dot.
+    domain.contains('.')
+        && psl::suffix(bytes).is_some_and(|s| s.typ().is_some() && s.as_bytes() == bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::DomainPart;
 
-    use super::{sanitize_domain, sanitize_email};
+    use super::{is_valid_domain, sanitize_domain, sanitize_email};
+
+    #[test]
+    fn public_suffix_domains_with_mailboxes_are_accepted() {
+        // eTLDs that host real, deliverable mailboxes directly on the suffix.
+        for domain in ["gov.in", "nic.in", "mil.in", "ac.in", "co.in"] {
+            assert!(is_valid_domain(domain), "{domain} should be valid");
+            assert_eq!(
+                sanitize_email(&format!("user@{domain}")).as_deref(),
+                Some(format!("user@{domain}").as_str()),
+                "user@{domain} should sanitize"
+            );
+        }
+
+        // Registrable domains under those suffixes remain valid.
+        assert!(is_valid_domain("example.gov.in"));
+
+        // Ordinary domains are unaffected.
+        assert!(is_valid_domain("example.com"));
+
+        // Bare TLDs / public suffixes without a leading label are still rejected.
+        assert!(!is_valid_domain("com"));
+        assert!(!is_valid_domain("in"));
+    }
 
     #[test]
     fn idn_domains_canonicalize_to_a_label() {


### PR DESCRIPTION
## Problem

When a JMAP client submits an email whose recipient (or sender) domain is itself a registered public suffix (eTLD) on the [Public Suffix List](https://publicsuffix.org/), `EmailSubmission/set` fails with `invalidProperties` on the `envelope`:

> Invalid e-mail address "user@gov.in".

`gov.in`, `nic.in`, `mil.in`, `ac.in`, `co.in`, etc. are all listed as public suffixes, yet NIC operates real, deliverable mailboxes directly at those domains. These addresses are RFC-valid and deliverable but were being rejected.

## Root cause

Envelope addresses are validated via `sanitize_email()` → `is_valid_domain()` in `crates/utils/src/lib.rs`. That check only accepted a **registrable domain** — a known public suffix plus at least one additional label:

```rust
psl::domain(domain.as_bytes()).is_some_and(|d| d.suffix().typ().is_some())
```

For a domain that *is* the public suffix (e.g. `gov.in`), `psl::domain()` returns `None`, so validation failed.

## Fix

A domain is now accepted when it is **either**:

1. A registrable domain (public suffix + ≥1 label) — unchanged behavior, and
2. Itself a multi-label public suffix (an eTLD), while still rejecting bare TLDs such as `com` or `in` (the domain must contain a dot).

This is applied in the shared `is_valid_domain()` helper, so it also fixes the same over-strict validation anywhere else it is used.

## Tests

Added `public_suffix_domains_with_mailboxes_are_accepted` covering acceptance of `gov.in`/`nic.in`/`mil.in`/`ac.in`/`co.in`, a subdomain (`example.gov.in`), an ordinary domain (`example.com`), and rejection of bare TLDs (`com`, `in`). The full `utils` suite passes.