### PR TITLE
fix(JMAP): EmailSubmission/set rejects recipients whose domain is a public suffix

### DIFF
--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -422,18 +422,44 @@ pub fn is_valid_domain(domain: &str) -> bool {
         "private",
         "localdomain",
     ];
-    psl::domain(domain.as_bytes()).is_some_and(|d| d.suffix().typ().is_some())
+    has_valid_public_suffix(domain)
         || RESERVED_TLDS.contains(&domain)
         || domain
             .rsplit_once('.')
             .is_some_and(|(_, tld)| RESERVED_TLDS.contains(&tld))
 }
 
+fn has_valid_public_suffix(domain: &str) -> bool {
+    let bytes = domain.as_bytes();
+
+    // A registrable domain, or an eTLD that hosts mailboxes directly (e.g. `gov.in`).
+    psl::domain(bytes).is_some_and(|d| d.suffix().typ().is_some())
+        || (domain.contains('.')
+            && psl::suffix(bytes).is_some_and(|s| s.typ().is_some() && s.as_bytes() == bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::DomainPart;
 
-    use super::{sanitize_domain, sanitize_email};
+    use super::{is_valid_domain, sanitize_domain, sanitize_email};
+
+    #[test]
+    fn public_suffix_domains_with_mailboxes_are_accepted() {
+        for domain in ["gov.in", "nic.in", "mil.in", "ac.in", "co.in"] {
+            assert!(is_valid_domain(domain), "{domain} should be valid");
+            assert_eq!(
+                sanitize_email(&format!("user@{domain}")).as_deref(),
+                Some(format!("user@{domain}").as_str()),
+                "user@{domain} should sanitize"
+            );
+        }
+
+        assert!(is_valid_domain("example.gov.in"));
+        assert!(is_valid_domain("example.com"));
+        assert!(!is_valid_domain("com"));
+        assert!(!is_valid_domain("in"));
+    }
 
     #[test]
     fn idn_domains_canonicalize_to_a_label() {


### PR DESCRIPTION
Ref: https://support.stalw.art/t/jmap-emailsubmission-set-rejects-valid-recipients-whose-domain-is-a-bare-public-suffix-e-g-gov-in-nic-in/1134