### PR TITLE
Generate a UID for JMAP-created calendar events when the client omits it (fixes silent iMIP no-op)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "tungstenite",
  "types",
  "utils",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/jmap/Cargo.toml
+++ b/crates/jmap/Cargo.toml
@@ -20,6 +20,7 @@ email = { path = "../email" }
 groupware = { path = "../groupware" }
 registry = { path = "../registry" }
 calcard = { version = "0.3" }
+uuid = { version = "1.24", features = ["v4"] }
 smtp-proto = { version = "0.2" }
 mail-parser = { version = "0.11", features = ["full_encoding", "rkyv"] } 
 mail-builder = { version = "0.4" }

--- a/crates/jmap/src/calendar_event/set.rs
+++ b/crates/jmap/src/calendar_event/set.rs
@@ -560,6 +560,26 @@ impl CalendarEventSet for Server {
             )));
         };
 
+        // RFC 8984 requires every JSCalendar object to have a uid. If the client
+        // did not provide one on create, generate it server-side. Without this,
+        // the stored iCalendar object has no UID line, which breaks CalDAV
+        // interoperability and causes itip_create() to fail with
+        // ItipError::MissingUid, silently skipping all scheduling messages.
+        if ical.uids().next().is_none() {
+            let uid = uuid::Uuid::new_v4().to_string();
+            for component in ical.components.iter_mut() {
+                if matches!(
+                    component.component_type,
+                    ICalendarComponentType::VEvent | ICalendarComponentType::VTodo
+                ) {
+                    component.entries.push(
+                        ICalendarEntry::new(ICalendarProperty::Uid)
+                            .with_value(uid.clone()),
+                    );
+                }
+            }
+        }
+
         // Verify that the calendar ids valid
         let default_alert_comp_id = ical.components.len();
         for name in &event.names {


### PR DESCRIPTION
## Problem

When a JMAP client calls `CalendarEvent/set` (create) without a `uid` — which JMAP clients legitimately do, including the bundled webmail — the server does not generate one. The JSCalendar→iCalendar conversion then produces a VEVENT **without a `UID:` line**, and:

1. `itip_create()` → `itip_snapshot()` fails with `ItipError::MissingUid` (`crates/groupware/src/scheduling/snapshot.rs`), and the create path **silently swallows** the error (non-`is_jmap_error` arm in `crates/jmap/src/calendar_event/set.rs`). Result: event created, `created` returned, **no scheduling message is ever sent** — even with `sendSchedulingMessages: true` — with no error and no log line.
2. The stored object violates RFC 8984 §4.1.2 (`uid` is mandatory) and the event is not usable as a CalDAV resource.

Verified on 0.16.12 and 0.16.14 with an instrumented build on a production server. Probe output for a uid-less create with participants (`scheduleAgent: "server"`, `sendSchedulingMessages: true`):

```
ITIP-DBG create gate: ssm=true enabled=true addrs=["user@…", …] perm=true range_end=1784896200 now=1784833508
ITIP-DBG create: itip_create ERR MissingUid
```

The same request with an explicit `uid` produces `itip_create OK, 1 msg` and the iMIP REQUEST is queued and delivered. The CalDAV PUT path is unaffected (the client supplies the UID inside the `.ics`).

This is likely the actual trigger behind discussion #2700 ("Unable to use iMIP with JMAP").

## Fix

Generate a v4 UUID server-side right after the JSCalendar→iCalendar conversion in the JMAP create path when no UID is present. `uuid` is already in the dependency graph; it is added as a direct dependency of the `jmap` crate.

Deployed on a production instance (0.16.14 + this patch): a uid-less `CalendarEvent/set` create now generates the UID, queues the iMIP REQUEST, and the invitation was delivered externally (Microsoft 365 round-trip observed in 16–26 s). `destroy` sends the CANCEL as expected.

## Possible follow-ups (not in this PR)

- Surface `ItipError` values that are not `is_jmap_error()` in tracing output instead of dropping them silently — this bug was invisible precisely because nothing was logged.
- The copy/import paths may also be able to produce uid-less objects and could reuse the same guard.
- Cosmetic: `CalendarEvent/get` does not return the `uid` property for events created via JMAP on 0.16.14 (observed on both uid-provided and generated cases).
