### PR TITLE
fix(meili): respect configured poll/retry/timeout settings during bootstrap index creation

### DIFF
--- a/crates/store/src/backend/meili/main.rs
+++ b/crates/store/src/backend/meili/main.rs
@@ -15,7 +15,7 @@ use crate::{
 use registry::schema::structs;
 use reqwest::{Error, Response, Url};
 use serde_json::{Value, json};
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 impl MeiliSearchStore {
     pub async fn open(config: structs::MeilisearchStore) -> Result<SearchStore, String> {
@@ -34,22 +34,16 @@ impl MeiliSearchStore {
         let ms = Self {
             client,
             url: config.url,
-            task_poll_interval: Duration::from_millis(500),
-            task_poll_retries: 120,
-            task_fail_on_timeout: true,
+            task_poll_interval: config.poll_interval.into_inner(),
+            task_poll_retries: config.max_retries as usize,
+            task_fail_on_timeout: config.fail_on_timeout,
         };
 
         if let Err(err) = ms.create_indexes().await {
             return Err(format!("Failed to create indexes: {err}"));
         }
 
-        Ok(SearchStore::MeiliSearch(Arc::new(MeiliSearchStore {
-            client: ms.client,
-            url: ms.url,
-            task_poll_interval: config.poll_interval.into_inner(),
-            task_poll_retries: config.max_retries as usize,
-            task_fail_on_timeout: config.fail_on_timeout,
-        })))
+        Ok(SearchStore::MeiliSearch(Arc::new(ms)))
     }
 
     pub async fn create_indexes(&self) -> trc::Result<()> {


### PR DESCRIPTION
## Bug

`MeiliSearchStore::open()` builds a temporary struct with hardcoded
`task_poll_interval=500ms`, `task_poll_retries=120`,
`task_fail_on_timeout=true` for the initial `create_indexes()` bootstrap
check, then discards it in favor of a second struct built from the
actually-configured values for runtime use:

```rust
let ms = Self {
    client,
    url: config.url,
    task_poll_interval: Duration::from_millis(500),
    task_poll_retries: 120,
    task_fail_on_timeout: true,
};

if let Err(err) = ms.create_indexes().await {
    return Err(format!("Failed to create indexes: {err}"));
}

Ok(SearchStore::MeiliSearch(Arc::new(MeiliSearchStore {
    client: ms.client,
    url: ms.url,
    task_poll_interval: config.poll_interval.into_inner(),
    task_poll_retries: config.max_retries as usize,
    task_fail_on_timeout: config.fail_on_timeout,
})))
```

If Meilisearch takes longer than the hardcoded 60s budget
(120 × 500ms) to respond during `create_indexes()` — for example
because it's still finishing an earlier batch on a large existing
index, where LMDB's single-writer commit can legitimately take well
over a minute — the whole `open()` call returns `Err` regardless of
what the user has configured for `failOnTimeout`/`maxRetries`/
`pollInterval`.

`Storage::parse` then does:

```rust
let search = SearchStore::build(bp).await.unwrap_or_default();
```

so this failure is silently swallowed and `search` becomes
`SearchStore::default()` (a no-op `Store::None`). Every subsequent
index/unindex task fails with `store.not-configured`
(`store.rs:46`) until the *next* restart — and since this binding is
only built once at process startup, there is no runtime recovery path.
Worse, the next restart isn't guaranteed to avoid the same race either,
since it depends on Meilisearch's queue state at that exact moment.

## Reproduction

1. Run Stalwart with a Meilisearch-backed `st_email` index that already
   has a non-trivial number of documents (our case: ~570k emails).
2. Restart the Stalwart container at a moment when Meilisearch is
   mid-batch on an existing task (e.g. during steady mail traffic).
3. If Meilisearch's response to the bootstrap `create_indexes()` call
   takes longer than 60s, `SearchStore::build` fails and falls back to
   `Store::None`.
4. Observed continuously in logs afterwards:
   `ERROR Store not configured (store.not-configured) ... details = "Failed to index documents"`
   and `"Failed to delete documents from index"`, with the affected
   `stalwart` process consuming ~1.3 CPU cores indefinitely retrying
   tasks that can never succeed until restarted again.
5. We confirmed this is timing-dependent, not deterministic: two
   consecutive restarts of the same instance, a few hours apart,
   produced different outcomes — one succeeded, one hit this exact
   timeout (`registry.build-error source = "SearchStore" ... reason =
   "Failed to create indexes: Meilisearch error
   (store.meilisearch-error): reason = Timed out waiting for
   Meilisearch task"`).

## Fix

Build the struct from `config` once and reuse it for both the
bootstrap check and the runtime store, instead of maintaining two
copies with different values. This means a user who has already set
`failOnTimeout: false` (or a larger `maxRetries`/`pollInterval`) to
tolerate a slow Meilisearch gets that same tolerance during startup,
not just at runtime — removing the silent fallback to an unconfigured
search store on a timing race.

## Environment

- Stalwart v0.16.14, Docker deployment
- Meilisearch 1.10.3, ~570k documents in the `st_email` index
- PostgreSQL data store

Confirmed `cargo check -p store` passes with no new warnings introduced.