### PR TITLE
Fix domain alias lookup for inbound RCPT

### DIFF
--- a/crates/common/src/cache/invalidate.rs
+++ b/crates/common/src/cache/invalidate.rs
@@ -113,6 +113,7 @@ impl CacheInvalidationBuilder {
 
             (ObjectInner::Domain(current), ObjectInner::Domain(new)) => {
                 if (current.name != new.name)
+                    || (current.aliases != new.aliases)
                     || (current.directory_id != new.directory_id)
                     || (current.member_tenant_id != new.member_tenant_id)
                     || (current.catch_all_address != new.catch_all_address)

--- a/crates/registry/src/schema/structs_impl.rs
+++ b/crates/registry/src/schema/structs_impl.rs
@@ -19702,6 +19702,9 @@ impl ObjectImpl for Domain {
         i.unique(Property::Name, &self.name);
         i.text(Property::Text, &self.name);
         for value in self.aliases.iter() {
+            // Aliases must be unique Name keys so domain("alias.tld") resolves
+            // for inbound RCPT without first warming the primary-name cache.
+            i.unique(Property::Name, value);
             i.text(Property::Text, value);
         }
         if let Some(value) = &self.description {

--- a/tests/src/system/directory.rs
+++ b/tests/src/system/directory.rs
@@ -60,6 +60,16 @@ pub async fn test(test: &TestServer) {
         Some("catchy@example.com")
     );
 
+    // Cold lookup by alias alone must resolve (not only after primary name is cached)
+    test.server.invalidate_all_local_caches();
+    let alias_domain = test
+        .server
+        .domain("beispiel.de")
+        .await
+        .unwrap()
+        .expect("domain alias must resolve without warming primary name cache");
+    assert_eq!(alias_domain.id, domain_id.document_id());
+
     // Multiple domains with the same name should not be allowed
     account
         .registry_create_object_expect_err(Domain {


### PR DESCRIPTION
Updated commit message on `fix/domain-alias-name-index` (pseudo domains only). PR body you can paste:

---

**Title:** Fix domain alias lookup for inbound RCPT

**Body:**

## Problem

When a Domain has additional names in `aliases` (for example primary `example.com` and alias `mail-alias.example`), inbound SMTP to `user@mail-alias.example` can fail with:

```
550 5.1.2 Relay not allowed
```

That response is emitted for `RcptResolution::UnknownDomain`: the server does not treat the alias as a local domain at all.

**Root cause:** `Server::domain()` resolves names via the Domain primary key on `Property::Name`. `Domain::index()` only registered the primary `name` as a unique Name key; aliases were text-indexed for search only. A cold lookup of an alias name therefore misses the store, caches a negative entry, and RCPT rejects the recipient as relay.

**Secondary issue:** updating `aliases` on an existing Domain did not invalidate the Domain cache, so newly added aliases also stayed invisible until restart or unrelated cache eviction. Even after a restart, the missing Name index still broke cold alias lookups.

## Fix

- Index each domain alias with `unique(Property::Name, …)` so `domain("mail-alias.example")` finds the same Domain object as the primary name.
- Invalidate the Domain cache when `aliases` change.
- Add a regression test that clears caches and resolves the alias without warming the primary name first.

## Upgrade note

After upgrading, re-save (or otherwise rewrite) existing Domain objects that already have aliases so their Name indexes are rebuilt.