### PR TITLE
JMAP Email: fetchAllBodyValues must include any text/* part

### DIFF
--- a/crates/jmap/src/email/get.rs
+++ b/crates/jmap/src/email/get.rs
@@ -400,14 +400,21 @@ impl EmailGet for Server {
                     EmailProperty::BodyValues => {
                         let mut body_values = Map::with_capacity(contents.parts.len());
                         for (part_id, part) in contents.parts.iter().enumerate() {
-                            if ((contents.is_html_part(part_id as u16)
-                                && (fetch_all_body_values || fetch_html_body_values))
-                                || (contents.is_text_part(part_id as u16)
-                                    && (fetch_all_body_values || fetch_text_body_values)))
-                                && matches!(
-                                    part.body,
-                                    ArchivedMetadataPartType::Text | ArchivedMetadataPartType::Html
-                                )
+                            // RFC 8621 section 4.2: fetchAllBodyValues includes any text/* part in bodyStructure,
+                            // not only parts listed in textBody or htmlBody. Per RFC 2045, a missing
+                            // Content-Type header defaults to text/plain.
+                            let is_text_type = part
+                                .content_type()
+                                .is_none_or(|ct| ct.ctype().eq_ignore_ascii_case("text"));
+                            if matches!(
+                                part.body,
+                                ArchivedMetadataPartType::Text | ArchivedMetadataPartType::Html
+                            ) && is_text_type
+                                && (fetch_all_body_values
+                                    || (contents.is_html_part(part_id as u16)
+                                        && fetch_html_body_values)
+                                    || (contents.is_text_part(part_id as u16)
+                                        && fetch_text_body_values))
                             {
                                 let contents = part.decode_contents(&raw_message);
 

--- a/crates/jmap/src/email/parse.rs
+++ b/crates/jmap/src/email/parse.rs
@@ -18,7 +18,7 @@ use jmap_proto::{
 };
 use jmap_tools::{Key, Map, Value};
 use mail_parser::{
-    HeaderName, MessageParser, PartType, decoders::html::html_to_text,
+    HeaderName, MessageParser, MimeHeaders, PartType, decoders::html::html_to_text,
     parsers::preview::preview_text,
 };
 use std::future::Future;
@@ -247,11 +247,19 @@ impl EmailParse for Server {
                         let mut body_values = Map::with_capacity(message.parts.len());
                         for (part_id, part) in message.parts.iter().enumerate() {
                             let part_id = part_id as u32;
-                            if ((message.html_body.contains(&part_id)
-                                && (fetch_all_body_values || fetch_html_body_values))
-                                || (message.text_body.contains(&part_id)
-                                    && (fetch_all_body_values || fetch_text_body_values)))
-                                && part.is_text()
+                            // RFC 8621 section 4.9: fetchAllBodyValues includes any text/* part in
+                            // bodyStructure, not only parts listed in textBody or htmlBody. Per RFC
+                            // 2045, a missing Content-Type header defaults to text/plain.
+                            let is_text_type = part
+                                .content_type()
+                                .is_none_or(|ct| ct.ctype().eq_ignore_ascii_case("text"));
+                            if part.is_text()
+                                && is_text_type
+                                && (fetch_all_body_values
+                                    || (message.html_body.contains(&part_id)
+                                        && fetch_html_body_values)
+                                    || (message.text_body.contains(&part_id)
+                                        && fetch_text_body_values))
                             {
                                 let (is_truncated, value) =
                                     part.body.truncate(max_body_value_bytes);

--- a/tests/resources/jmap/email_get/multipart_mixed.json
+++ b/tests/resources/jmap/email_get/multipart_mixed.json
@@ -153,6 +153,11 @@
       "value": "This could have been part of the previous part, but\nillustrates explicit versus implicit typing o...",
       "isEncodingProblem": false,
       "isTruncated": true
+    },
+    "6": {
+      "value": "This is <bold><italic>enriched.</italic></bold>\n<smaller>as defined in RFC 1896</smaller>\n\nIsn't ...",
+      "isEncodingProblem": false,
+      "isTruncated": true
     }
   },
   "textBody": [

--- a/tests/src/jmap/mail/parse.rs
+++ b/tests/src/jmap/mail/parse.rs
@@ -145,6 +145,36 @@ pub async fn test(test: &TestServer) {
         }
     }
 
+    // fetchAllBodyValues includes text/* attachments, but not non-text parts
+    // reclassified as text after a transfer-decoding failure.
+    let test_file = test_dir
+        .parent()
+        .unwrap()
+        .join("email_get")
+        .join("multipart_mixed.eml");
+    let blob_id = client
+        .upload(None, fs::read(test_file).unwrap(), None)
+        .await
+        .unwrap()
+        .take_blob_id();
+    let mut request = client.build();
+    request
+        .parse_email()
+        .blob_ids([blob_id.as_str()])
+        .properties([email::Property::BodyValues])
+        .fetch_all_body_values(true)
+        .max_body_value_bytes(100);
+    let email = request
+        .send_parse_email()
+        .await
+        .unwrap()
+        .parsed(&blob_id)
+        .unwrap();
+
+    assert!(email.body_value("6").is_some());
+    assert!(email.body_value("4").is_none());
+    assert!(email.body_value("5").is_none());
+
     // Test header parsing on a temporary blob
     let mut test_file = test_dir;
     test_file.push("headers.eml");


### PR DESCRIPTION
## Summary

RFC 8621 Sections 4.2 and 4.9 require fetchAllBodyValues to return every text/* part in bodyStructure.

Stalwart currently limits the result to parts in textBody or htmlBody. This omits text attachments and types such as text/enriched, and I believe, as per my understanding of the RFC (and checked Apache James) is not a conform behavior.

This change (attempt) to conform with the RFC:

  - Checks all `bodyStructure` parts for `Email/get` and `Email/parse`.
  - Uses the declared Content-Type to exclude non-text parts that MIME recovery classifies as text.
  - Treats a missing Content-Type as `text/plain`.
  - Adds tests for text attachments and malformed audio/image parts.

## Apache James reference

Apache James uses the same interpretation as I did. Email/get and Email/parse process bodyStructure.flatten. James selection logic (https://github.com/apache/james-project/blob/d8eb1ea0cee379ff9f8eb38dd194967052f3a7a4/server/protocols/jmap-rfc-8621/src/main/scala/org/apache/james/jmap/mail/Email.scala#L556-L582)

Mime4j maps declared text/* parts to TextBody and other media types to binary bodies. Mime4j classification
  (https://github.com/apache/james-mime4j/blob/168f2dbf0f7744a14a7bff09dde0a00c81724ffe/dom/src/main/java/org/apache/james/mime4j/internal/ParserStreamContentHandler.java#L124-L132)

Its integration test returns two text/plain attachments and excludes an application/vnd.ms-publisher attachment. James integration test
  (https://github.com/apache/james-project/blob/d8eb1ea0cee379ff9f8eb38dd194967052f3a7a4/server/protocols/jmap-rfc-8621-integration-tests/jmap-rfc-8621-integration-tests-common/src/main/scala/org/apache/james/jmap/rfc8621/contract/EmailGetMethodContract.scala#L5509-L5573)

## RFC 

https://datatracker.ietf.org/doc/html/rfc8621#section-4.2