### PR TITLE
Feature/ical publish links

### DIFF
--- a/crates/groupware/src/calendar/mod.rs
+++ b/crates/groupware/src/calendar/mod.rs
@@ -9,6 +9,8 @@ pub mod dates;
 pub mod expand;
 pub mod index;
 pub mod itip;
+pub mod publish_link;
+pub mod publish_http;
 pub mod storage;
 
 use calcard::icalendar::{

--- a/crates/groupware/src/calendar/publish_http.rs
+++ b/crates/groupware/src/calendar/publish_http.rs
@@ -1,0 +1,414 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+use calcard::icalendar::{
+    ICalendar, ICalendarComponentType, ICalendarEntry, ICalendarProperty, ICalendarValue,
+};
+use common::{DavResource, Server};
+use directory::core::secret::{hash_secret, verify_secret_hash};
+use crate::cache::GroupwareCache;
+use registry::schema::enums::PasswordHashAlgorithm;
+use store::{
+    Deserialize, IterateParams, ValueKey,
+    write::{AlignedBytes, Archive, Archiver, BatchBuilder, ValueClass, now},
+};
+use trc::AddContext;
+use types::{TimeRange, collection::Collection, collection::SyncCollection};
+
+use super::publish_link::{
+    CalendarPublishLink, FEED_FUTURE_SECONDS, FEED_PAST_SECONDS, LAST_USED_DEBOUNCE_SECONDS,
+    PublishAccess, PublishLinkSecret, PublishVisibility, format_uuid, parse_uuid,
+};
+
+pub trait CalendarPublishStore: Sync + Send {
+    fn get_publish_link(
+        &self,
+        account_id: u32,
+        link_id: [u8; 16],
+    ) -> impl Future<Output = trc::Result<Option<CalendarPublishLink>>> + Send;
+
+    fn lookup_publish_link_account(
+        &self,
+        link_id: [u8; 16],
+    ) -> impl Future<Output = trc::Result<Option<u32>>> + Send;
+
+    fn verify_publish_link_access(
+        &self,
+        link_id: [u8; 16],
+        secret: Option<&str>,
+        is_public: bool,
+    ) -> impl Future<Output = trc::Result<(u32, CalendarPublishLink)>> + Send;
+
+    fn export_calendar_publish_feed(
+        &self,
+        account_id: u32,
+        link: &CalendarPublishLink,
+    ) -> impl Future<Output = trc::Result<String>> + Send;
+}
+
+impl CalendarPublishStore for Server {
+    async fn get_publish_link(
+        &self,
+        account_id: u32,
+        link_id: [u8; 16],
+    ) -> trc::Result<Option<CalendarPublishLink>> {
+        let value = self
+            .store()
+            .get_value::<Archive<AlignedBytes>>(ValueKey::from(ValueClass::CalendarPublishLink {
+                link_id,
+                account_id,
+            }))
+            .await
+            .caused_by(trc::location!())?;
+        value
+            .map(|archive| {
+                archive
+                    .unarchive::<CalendarPublishLink>()
+                    .caused_by(trc::location!())
+            })
+            .transpose()
+    }
+
+    async fn lookup_publish_link_account(&self, link_id: [u8; 16]) -> trc::Result<Option<u32>> {
+        self.store()
+            .get_value::<u32>(ValueKey::from(ValueClass::CalendarPublishLinkLookup { link_id }))
+            .await
+            .caused_by(trc::location!())
+    }
+
+    async fn verify_publish_link_access(
+        &self,
+        link_id: [u8; 16],
+        secret: Option<&str>,
+        is_public: bool,
+    ) -> trc::Result<(u32, CalendarPublishLink)> {
+        let account_id = self
+            .lookup_publish_link_account(link_id)
+            .await?
+            .ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+        let link = self
+            .get_publish_link(account_id, link_id)
+            .await?
+            .ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+
+        if is_public && link.access != PublishAccess::Public {
+            return Err(trc::HttpEvent::NotFound.into_err());
+        }
+        if !is_public {
+            if link.access != PublishAccess::Private {
+                return Err(trc::HttpEvent::NotFound.into_err());
+            }
+            let Some(secret_hash) = &link.secret_hash else {
+                return Err(trc::HttpEvent::NotFound.into_err());
+            };
+            let provided = secret.ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+            if !verify_secret_hash(secret_hash, provided.as_bytes()).await? {
+                return Err(trc::HttpEvent::NotFound.into_err());
+            }
+        }
+
+        let now_ts = now() as i64;
+        if let Some(expires) = link.expires_at
+            && expires <= now_ts
+        {
+            return Err(trc::HttpEvent::NotFound.into_err());
+        }
+
+        Ok((account_id, link))
+    }
+
+    async fn export_calendar_publish_feed(
+        &self,
+        account_id: u32,
+        link: &CalendarPublishLink,
+    ) -> trc::Result<String> {
+        let resources = self
+            .fetch_dav_resources(account_id, account_id, SyncCollection::Calendar)
+            .await
+            .caused_by(trc::location!())?;
+        let calendar_id = link.calendar_id;
+        if !resources.has_container_id(&calendar_id) {
+            return Err(trc::HttpEvent::NotFound.into_err());
+        }
+
+        let now_ts = now() as i64;
+        let range = TimeRange {
+            start: now_ts - FEED_PAST_SECONDS,
+            end: now_ts + FEED_FUTURE_SECONDS,
+        };
+
+        let mut ical = ICalendar {
+            components: vec![calcard::icalendar::ICalendarComponent {
+                component_type: ICalendarComponentType::VCalendar,
+                entries: vec![
+                    ICalendarEntry {
+                        name: ICalendarProperty::Version,
+                        params: vec![],
+                        values: vec![ICalendarValue::Text("2.0".to_string())],
+                    },
+                    ICalendarEntry {
+                        name: ICalendarProperty::Prodid,
+                        params: vec![],
+                        values: vec![ICalendarValue::Text(
+                            "-//Stalwart Labs LLC//Stalwart//EN".to_string(),
+                        )],
+                    },
+                ],
+                component_ids: vec![],
+            }],
+        };
+
+        for resource in resources.children(calendar_id) {
+            if !is_resource_in_time_range(resource.resource, &range) {
+                continue;
+            }
+            let event_ = self
+                .store()
+                .get_value::<Archive<AlignedBytes>>(ValueKey::archive(
+                    account_id,
+                    Collection::CalendarEvent,
+                    resource.document_id(),
+                ))
+                .await
+                .caused_by(trc::location!())?;
+            if let Some(event_) = event_ {
+                let event = event_
+                    .unarchive::<super::CalendarEvent>()
+                    .caused_by(trc::location!())?;
+                let mut event_ical = event.data.event.clone();
+                apply_publish_visibility(&mut event_ical, link.visibility);
+                merge_events_into_calendar(&mut ical, &event_ical);
+            }
+        }
+
+        Ok(ical.to_string())
+    }
+}
+
+impl Server {
+    pub fn store_publish_link(
+        &self,
+        batch: &mut BatchBuilder,
+        account_id: u32,
+        link: &CalendarPublishLink,
+    ) -> trc::Result<()> {
+        let archive = Archiver::archive(link).caused_by(trc::location!())?;
+        batch.set(
+            ValueClass::CalendarPublishLink {
+                link_id: link.link_id,
+                account_id,
+            },
+            archive.serialize(),
+        );
+        batch.set(
+            ValueClass::CalendarPublishLinkLookup {
+                link_id: link.link_id,
+            },
+            account_id,
+        );
+        Ok(())
+    }
+
+    pub fn clear_publish_link(batch: &mut BatchBuilder, account_id: u32, link_id: [u8; 16]) {
+        batch.clear(ValueClass::CalendarPublishLink {
+            link_id,
+            account_id,
+        });
+        batch.clear(ValueClass::CalendarPublishLinkLookup { link_id });
+    }
+
+    pub async fn list_publish_links(
+        &self,
+        account_id: u32,
+    ) -> trc::Result<Vec<CalendarPublishLink>> {
+        let begin = ValueKey::from(ValueClass::CalendarPublishLink {
+            link_id: [0u8; 16],
+            account_id,
+        });
+        let end = ValueKey::from(ValueClass::CalendarPublishLink {
+            link_id: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+            account_id,
+        });
+        let mut links = Vec::new();
+        self.store()
+            .iterate(
+                IterateParams::new(begin, end).ascending(),
+                |_, value| {
+                    let archive = Archive::<AlignedBytes>::deserialize(value)
+                        .caused_by(trc::location!())?;
+                    links.push(
+                        archive
+                            .unarchive::<CalendarPublishLink>()
+                            .caused_by(trc::location!())?,
+                    );
+                    Ok(true)
+                },
+            )
+            .await
+            .caused_by(trc::location!())?;
+        Ok(links)
+    }
+
+    pub fn ics_publish_base_url(&self) -> String {
+        if let Some(url) = &self.core.groupware.itip_http_rsvp_url {
+            url.replace("/calendar/rsvp", "")
+                .trim_end_matches('/')
+                .to_string()
+        } else {
+            format!(
+                "https://{}",
+                self.core.email.system.default_hostname.as_str()
+            )
+        }
+    }
+
+    pub fn build_publish_url(&self, link: &CalendarPublishLink, secret: Option<&str>) -> String {
+        let base = self.ics_publish_base_url();
+        let id = format_uuid(&link.link_id);
+        match link.access {
+            PublishAccess::Public => format!("{base}/ics/public/{id}.ics"),
+            PublishAccess::Private => {
+                if let Some(secret) = secret {
+                    format!("{base}/ics/{id}/{secret}.ics")
+                } else {
+                    format!("{base}/ics/{id}/")
+                }
+            }
+        }
+    }
+
+    pub async fn hash_publish_secret(secret: &[u8]) -> trc::Result<String> {
+        hash_secret(PasswordHashAlgorithm::Argon2id, secret.to_vec()).await
+    }
+
+    pub async fn touch_publish_link_if_stale(
+        &self,
+        account_id: u32,
+        link: &CalendarPublishLink,
+    ) -> trc::Result<()> {
+        let now_ts = now() as i64;
+        if link
+            .last_used_at
+            .is_none_or(|t| now_ts - t >= LAST_USED_DEBOUNCE_SECONDS)
+        {
+            let mut updated = link.clone();
+            updated.last_used_at = Some(now_ts);
+            let mut batch = BatchBuilder::new();
+            self.store_publish_link(&mut batch, account_id, &updated)?;
+            self.commit_batch(batch).await.caused_by(trc::location!())?;
+        }
+        Ok(())
+    }
+}
+
+pub fn parse_ics_http_path(path: &str) -> trc::Result<([u8; 16], Option<String>, bool)> {
+    let parts: Vec<&str> = path.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() == 2 && parts[0] == "public" {
+        let link_id = parse_uuid(parts[1]).ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+        return Ok((link_id, None, true));
+    }
+    if parts.len() == 2 {
+        let link_id = parse_uuid(parts[0]).ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+        let secret = parts[1]
+            .strip_suffix(".ics")
+            .unwrap_or(parts[1])
+            .to_string();
+        return Ok((link_id, Some(secret), false));
+    }
+    Err(trc::HttpEvent::NotFound.into_err())
+}
+
+fn is_resource_in_time_range(resource: &DavResource, filter: &TimeRange) -> bool {
+    if let Some((start, end)) = resource.event_time_range() {
+        ((filter.start < end) || (filter.start <= start)) && (filter.end > start || filter.end >= end)
+    } else {
+        false
+    }
+}
+
+fn merge_events_into_calendar(target: &mut ICalendar, source: &ICalendar) {
+    let mut push_vevent = |component: &calcard::icalendar::ICalendarComponent| {
+        if component.component_type != ICalendarComponentType::VEvent {
+            return;
+        }
+        let new_id = target.components.len() as u32;
+        target.components.push(component.clone());
+        if let Some(vcal) = target
+            .components
+            .first_mut()
+            .filter(|c| c.component_type == ICalendarComponentType::VCalendar)
+        {
+            vcal.component_ids.push(new_id);
+        }
+    };
+
+    for component in &source.components {
+        if component.component_type == ICalendarComponentType::VCalendar {
+            for child_id in &component.component_ids {
+                if let Some(child) = source.components.get(*child_id as usize) {
+                    push_vevent(child);
+                }
+            }
+        } else {
+            push_vevent(component);
+        }
+    }
+}
+
+fn apply_publish_visibility(ical: &mut ICalendar, visibility: PublishVisibility) {
+    for component in &mut ical.components {
+        if component.component_type != ICalendarComponentType::VEvent {
+            continue;
+        }
+        let is_private = component.entries.iter().any(|entry| {
+            entry.name == ICalendarProperty::Class
+                && entry
+                    .values
+                    .first()
+                    .is_some_and(|v| matches!(v, ICalendarValue::Text(t) if t.eq_ignore_ascii_case("PRIVATE")))
+        });
+        if visibility == PublishVisibility::Busy || is_private {
+            redact_event_to_busy(component);
+        }
+    }
+}
+
+fn redact_event_to_busy(component: &mut calcard::icalendar::ICalendarComponent) {
+    component.entries.retain(|entry| {
+        !matches!(
+            entry.name,
+            ICalendarProperty::Location
+                | ICalendarProperty::Description
+                | ICalendarProperty::Attendee
+                | ICalendarProperty::Organizer
+                | ICalendarProperty::Url
+                | ICalendarProperty::Alarm
+        )
+    });
+    component.component_ids.clear();
+    if let Some(summary) = component
+        .entries
+        .iter_mut()
+        .find(|e| e.name == ICalendarProperty::Summary)
+    {
+        summary.values = vec![ICalendarValue::Text("Busy".to_string())];
+    } else {
+        component.entries.push(ICalendarEntry {
+            name: ICalendarProperty::Summary,
+            params: vec![],
+            values: vec![ICalendarValue::Text("Busy".to_string())],
+        });
+    }
+}
+
+pub async fn create_publish_link_secret() -> (PublishLinkSecret, String) {
+    let secret = PublishLinkSecret::new();
+    let token = secret.build();
+    let hash = hash_secret(PasswordHashAlgorithm::Argon2id, token.as_bytes().to_vec())
+        .await
+        .expect("hash failed");
+    (secret, hash)
+}

--- a/crates/groupware/src/calendar/publish_http.rs
+++ b/crates/groupware/src/calendar/publish_http.rs
@@ -12,7 +12,7 @@ use directory::core::secret::{hash_secret, verify_secret_hash};
 use crate::cache::GroupwareCache;
 use registry::schema::enums::PasswordHashAlgorithm;
 use store::{
-    Deserialize, IterateParams, ValueKey,
+    Deserialize, IterateParams, Serialize, SerializeInfallible, ValueKey,
     write::{AlignedBytes, Archive, Archiver, BatchBuilder, ValueClass, now},
 };
 use trc::AddContext;
@@ -47,6 +47,38 @@ pub trait CalendarPublishStore: Sync + Send {
         account_id: u32,
         link: &CalendarPublishLink,
     ) -> impl Future<Output = trc::Result<String>> + Send;
+
+    fn store_publish_link(
+        &self,
+        batch: &mut BatchBuilder,
+        account_id: u32,
+        link: &CalendarPublishLink,
+    ) -> trc::Result<()>;
+
+    fn list_publish_links(
+        &self,
+        account_id: u32,
+    ) -> impl Future<Output = trc::Result<Vec<CalendarPublishLink>>> + Send;
+
+    fn build_publish_url(&self, link: &CalendarPublishLink, secret: Option<&str>) -> String;
+
+    fn touch_publish_link_if_stale(
+        &self,
+        account_id: u32,
+        link: &CalendarPublishLink,
+    ) -> impl Future<Output = trc::Result<()>> + Send;
+}
+
+pub fn clear_publish_link(batch: &mut BatchBuilder, account_id: u32, link_id: [u8; 16]) {
+    batch.clear(ValueClass::CalendarPublishLink {
+        link_id,
+        account_id,
+    });
+    batch.clear(ValueClass::CalendarPublishLinkLookup { link_id });
+}
+
+fn not_found() -> trc::Error {
+    trc::ResourceEvent::NotFound.into_err()
 }
 
 impl CalendarPublishStore for Server {
@@ -64,11 +96,7 @@ impl CalendarPublishStore for Server {
             .await
             .caused_by(trc::location!())?;
         value
-            .map(|archive| {
-                archive
-                    .unarchive::<CalendarPublishLink>()
-                    .caused_by(trc::location!())
-            })
+            .map(|archive| archive.deserialize::<CalendarPublishLink>())
             .transpose()
     }
 
@@ -88,25 +116,25 @@ impl CalendarPublishStore for Server {
         let account_id = self
             .lookup_publish_link_account(link_id)
             .await?
-            .ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+            .ok_or_else(not_found)?;
         let link = self
             .get_publish_link(account_id, link_id)
             .await?
-            .ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+            .ok_or_else(not_found)?;
 
         if is_public && link.access != PublishAccess::Public {
-            return Err(trc::HttpEvent::NotFound.into_err());
+            return Err(not_found());
         }
         if !is_public {
             if link.access != PublishAccess::Private {
-                return Err(trc::HttpEvent::NotFound.into_err());
+                return Err(not_found());
             }
             let Some(secret_hash) = &link.secret_hash else {
-                return Err(trc::HttpEvent::NotFound.into_err());
+                return Err(not_found());
             };
-            let provided = secret.ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+            let provided = secret.ok_or_else(not_found)?;
             if !verify_secret_hash(secret_hash, provided.as_bytes()).await? {
-                return Err(trc::HttpEvent::NotFound.into_err());
+                return Err(not_found());
             }
         }
 
@@ -114,7 +142,7 @@ impl CalendarPublishStore for Server {
         if let Some(expires) = link.expires_at
             && expires <= now_ts
         {
-            return Err(trc::HttpEvent::NotFound.into_err());
+            return Err(not_found());
         }
 
         Ok((account_id, link))
@@ -131,7 +159,7 @@ impl CalendarPublishStore for Server {
             .caused_by(trc::location!())?;
         let calendar_id = link.calendar_id;
         if !resources.has_container_id(&calendar_id) {
-            return Err(trc::HttpEvent::NotFound.into_err());
+            return Err(not_found());
         }
 
         let now_ts = now() as i64;
@@ -176,9 +204,9 @@ impl CalendarPublishStore for Server {
                 .caused_by(trc::location!())?;
             if let Some(event_) = event_ {
                 let event = event_
-                    .unarchive::<super::CalendarEvent>()
+                    .deserialize::<super::CalendarEvent>()
                     .caused_by(trc::location!())?;
-                let mut event_ical = event.data.event.clone();
+                let mut event_ical = event.data.event;
                 apply_publish_visibility(&mut event_ical, link.visibility);
                 merge_events_into_calendar(&mut ical, &event_ical);
             }
@@ -186,41 +214,31 @@ impl CalendarPublishStore for Server {
 
         Ok(ical.to_string())
     }
-}
 
-impl Server {
-    pub fn store_publish_link(
+    fn store_publish_link(
         &self,
         batch: &mut BatchBuilder,
         account_id: u32,
         link: &CalendarPublishLink,
     ) -> trc::Result<()> {
-        let archive = Archiver::archive(link).caused_by(trc::location!())?;
+        let archive = Archiver::new(link.clone());
         batch.set(
             ValueClass::CalendarPublishLink {
                 link_id: link.link_id,
                 account_id,
             },
-            archive.serialize(),
+            archive.serialize()?,
         );
         batch.set(
             ValueClass::CalendarPublishLinkLookup {
                 link_id: link.link_id,
             },
-            account_id,
+            account_id.serialize(),
         );
         Ok(())
     }
 
-    pub fn clear_publish_link(batch: &mut BatchBuilder, account_id: u32, link_id: [u8; 16]) {
-        batch.clear(ValueClass::CalendarPublishLink {
-            link_id,
-            account_id,
-        });
-        batch.clear(ValueClass::CalendarPublishLinkLookup { link_id });
-    }
-
-    pub async fn list_publish_links(
+    async fn list_publish_links(
         &self,
         account_id: u32,
     ) -> trc::Result<Vec<CalendarPublishLink>> {
@@ -237,11 +255,12 @@ impl Server {
             .iterate(
                 IterateParams::new(begin, end).ascending(),
                 |_, value| {
-                    let archive = Archive::<AlignedBytes>::deserialize(value)
-                        .caused_by(trc::location!())?;
+                    let archive =
+                        <Archive<AlignedBytes> as Deserialize>::deserialize(value)
+                            .caused_by(trc::location!())?;
                     links.push(
                         archive
-                            .unarchive::<CalendarPublishLink>()
+                            .deserialize::<CalendarPublishLink>()
                             .caused_by(trc::location!())?,
                     );
                     Ok(true)
@@ -252,21 +271,14 @@ impl Server {
         Ok(links)
     }
 
-    pub fn ics_publish_base_url(&self) -> String {
-        if let Some(url) = &self.core.groupware.itip_http_rsvp_url {
+    fn build_publish_url(&self, link: &CalendarPublishLink, secret: Option<&str>) -> String {
+        let base = if let Some(url) = &self.core.groupware.itip_http_rsvp_url {
             url.replace("/calendar/rsvp", "")
                 .trim_end_matches('/')
                 .to_string()
         } else {
-            format!(
-                "https://{}",
-                self.core.email.system.default_hostname.as_str()
-            )
-        }
-    }
-
-    pub fn build_publish_url(&self, link: &CalendarPublishLink, secret: Option<&str>) -> String {
-        let base = self.ics_publish_base_url();
+            format!("https://{}", self.core.email.default_domain_name.as_str())
+        };
         let id = format_uuid(&link.link_id);
         match link.access {
             PublishAccess::Public => format!("{base}/ics/public/{id}.ics"),
@@ -280,11 +292,7 @@ impl Server {
         }
     }
 
-    pub async fn hash_publish_secret(secret: &[u8]) -> trc::Result<String> {
-        hash_secret(PasswordHashAlgorithm::Argon2id, secret.to_vec()).await
-    }
-
-    pub async fn touch_publish_link_if_stale(
+    async fn touch_publish_link_if_stale(
         &self,
         account_id: u32,
         link: &CalendarPublishLink,
@@ -307,18 +315,18 @@ impl Server {
 pub fn parse_ics_http_path(path: &str) -> trc::Result<([u8; 16], Option<String>, bool)> {
     let parts: Vec<&str> = path.split('/').filter(|p| !p.is_empty()).collect();
     if parts.len() == 2 && parts[0] == "public" {
-        let link_id = parse_uuid(parts[1]).ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+        let link_id = parse_uuid(parts[1]).ok_or_else(not_found)?;
         return Ok((link_id, None, true));
     }
     if parts.len() == 2 {
-        let link_id = parse_uuid(parts[0]).ok_or_else(|| trc::HttpEvent::NotFound.into_err())?;
+        let link_id = parse_uuid(parts[0]).ok_or_else(not_found)?;
         let secret = parts[1]
             .strip_suffix(".ics")
             .unwrap_or(parts[1])
             .to_string();
         return Ok((link_id, Some(secret), false));
     }
-    Err(trc::HttpEvent::NotFound.into_err())
+    Err(not_found())
 }
 
 fn is_resource_in_time_range(resource: &DavResource, filter: &TimeRange) -> bool {
@@ -385,7 +393,6 @@ fn redact_event_to_busy(component: &mut calcard::icalendar::ICalendarComponent) 
                 | ICalendarProperty::Attendee
                 | ICalendarProperty::Organizer
                 | ICalendarProperty::Url
-                | ICalendarProperty::Alarm
         )
     });
     component.component_ids.clear();

--- a/crates/groupware/src/calendar/publish_http.rs
+++ b/crates/groupware/src/calendar/publish_http.rs
@@ -342,6 +342,10 @@ fn is_resource_in_time_range(resource: &DavResource, filter: &TimeRange) -> bool
 }
 
 fn merge_events_into_calendar(target: &mut ICalendar, source: &ICalendar) {
+    // Non-IANA / embedded zones live in VTIMEZONE siblings; without these,
+    // subscribers see floating or wrong local times for those events.
+    target.copy_timezones(source);
+
     let mut push_vevent = |component: &calcard::icalendar::ICalendarComponent| {
         if component.component_type != ICalendarComponentType::VEvent {
             return;

--- a/crates/groupware/src/calendar/publish_http.rs
+++ b/crates/groupware/src/calendar/publish_http.rs
@@ -272,7 +272,11 @@ impl CalendarPublishStore for Server {
     }
 
     fn build_publish_url(&self, link: &CalendarPublishLink, secret: Option<&str>) -> String {
-        let base = if let Some(url) = &self.core.groupware.itip_http_rsvp_url {
+        let base = if !self.core.network.http.url_https.is_empty() {
+            self.core.network.http.url_https
+                .trim_end_matches('/')
+                .to_string()
+        } else if let Some(url) = &self.core.groupware.itip_http_rsvp_url {
             url.replace("/calendar/rsvp", "")
                 .trim_end_matches('/')
                 .to_string()

--- a/crates/groupware/src/calendar/publish_http.rs
+++ b/crates/groupware/src/calendar/publish_http.rs
@@ -377,10 +377,10 @@ fn apply_publish_visibility(ical: &mut ICalendar, visibility: PublishVisibility)
         }
         let is_private = component.entries.iter().any(|entry| {
             entry.name == ICalendarProperty::Class
-                && entry
-                    .values
-                    .first()
-                    .is_some_and(|v| matches!(v, ICalendarValue::Text(t) if t.eq_ignore_ascii_case("PRIVATE")))
+                && entry.values.first().is_some_and(|v| {
+                    matches!(v, ICalendarValue::Text(t)
+                        if t.eq_ignore_ascii_case("PRIVATE") || t.eq_ignore_ascii_case("CONFIDENTIAL"))
+                })
         });
         if visibility == PublishVisibility::Busy || is_private {
             redact_event_to_busy(component);

--- a/crates/groupware/src/calendar/publish_link.rs
+++ b/crates/groupware/src/calendar/publish_link.rs
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+use std::io::Write;
+use store::rand;
+use utils::codec::base32_custom::{Base32Reader, Base32Writer};
+
+pub const MAX_PRIVATE_LINKS_PER_CALENDAR: usize = 20;
+pub const MAX_PUBLIC_LINKS_PER_CALENDAR: usize = 2;
+pub const FEED_PAST_SECONDS: i64 = 30 * 86400;
+pub const FEED_FUTURE_SECONDS: i64 = 2 * 365 * 86400;
+pub const LAST_USED_DEBOUNCE_SECONDS: i64 = 3600;
+
+#[derive(
+    rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, Debug, Clone, Copy, PartialEq, Eq, Default,
+)]
+#[repr(u8)]
+pub enum PublishAccess {
+    #[default]
+    Private = 0,
+    Public = 1,
+}
+
+#[derive(
+    rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, Debug, Clone, Copy, PartialEq, Eq, Default,
+)]
+#[repr(u8)]
+pub enum PublishVisibility {
+    #[default]
+    Full = 0,
+    Busy = 1,
+}
+
+#[derive(
+    rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, Debug, Clone, PartialEq, Eq, Default,
+)]
+pub struct CalendarPublishLink {
+    pub link_id: [u8; 16],
+    pub calendar_id: u32,
+    pub access: PublishAccess,
+    pub visibility: PublishVisibility,
+    pub label: Option<String>,
+    pub secret_hash: Option<String>,
+    pub created_at: i64,
+    pub last_used_at: Option<i64>,
+    pub expires_at: Option<i64>,
+}
+
+pub struct PublishLinkSecret {
+    pub secret: [u8; 18],
+}
+
+impl PublishLinkSecret {
+    pub fn new() -> Self {
+        PublishLinkSecret {
+            secret: rand::random(),
+        }
+    }
+
+    pub fn parse(token: &str) -> Option<Self> {
+        let mut reader = Base32Reader::new(token.as_bytes());
+        let mut secret = [0u8; 18];
+        for byte in secret.iter_mut() {
+            *byte = reader.next()?;
+        }
+        if reader.next().is_none() {
+            Some(PublishLinkSecret { secret })
+        } else {
+            None
+        }
+    }
+
+    pub fn build(&self) -> String {
+        let mut writer = Base32Writer::with_capacity(32);
+        let _ = writer.write_all(&self.secret);
+        writer.finalize()
+    }
+}
+
+impl CalendarPublishLink {
+    pub fn new(
+        calendar_id: u32,
+        access: PublishAccess,
+        visibility: PublishVisibility,
+        label: Option<String>,
+        secret_hash: Option<String>,
+        created_at: i64,
+        expires_at: Option<i64>,
+    ) -> Self {
+        CalendarPublishLink {
+            link_id: rand::random(),
+            calendar_id,
+            access,
+            visibility,
+            label,
+            secret_hash,
+            created_at,
+            last_used_at: None,
+            expires_at,
+        }
+    }
+
+    pub fn link_id_string(&self) -> String {
+        format_uuid(&self.link_id)
+    }
+}
+
+pub fn format_uuid(bytes: &[u8; 16]) -> String {
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15]
+    )
+}
+
+pub fn parse_uuid(s: &str) -> Option<[u8; 16]> {
+    let s = s.strip_suffix(".ics").unwrap_or(s);
+    if s.len() != 36 {
+        return None;
+    }
+    let bytes = [
+        parse_hex_pair(s.get(0..2)?)?,
+        parse_hex_pair(s.get(2..4)?)?,
+        parse_hex_pair(s.get(4..6)?)?,
+        parse_hex_pair(s.get(6..8)?)?,
+        parse_hex_pair(s.get(9..11)?)?,
+        parse_hex_pair(s.get(11..13)?)?,
+        parse_hex_pair(s.get(14..16)?)?,
+        parse_hex_pair(s.get(16..18)?)?,
+        parse_hex_pair(s.get(19..21)?)?,
+        parse_hex_pair(s.get(21..23)?)?,
+        parse_hex_pair(s.get(24..26)?)?,
+        parse_hex_pair(s.get(26..28)?)?,
+        parse_hex_pair(s.get(28..30)?)?,
+        parse_hex_pair(s.get(30..32)?)?,
+        parse_hex_pair(s.get(32..34)?)?,
+        parse_hex_pair(s.get(34..36)?)?,
+    ];
+    if s.chars().nth(8) != Some('-')
+        || s.chars().nth(13) != Some('-')
+        || s.chars().nth(18) != Some('-')
+        || s.chars().nth(23) != Some('-')
+    {
+        return None;
+    }
+    Some(bytes)
+}
+
+fn parse_hex_pair(s: &str) -> Option<u8> {
+    let hi = s.chars().next()?.to_digit(16)?;
+    let lo = s.chars().nth(1)?.to_digit(16)?;
+    Some((hi << 4 | lo) as u8)
+}
+

--- a/crates/groupware/src/calendar/publish_link.rs
+++ b/crates/groupware/src/calendar/publish_link.rs
@@ -38,6 +38,7 @@ pub enum PublishVisibility {
     rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, Debug, Clone, PartialEq, Eq, Default,
 )]
 pub struct CalendarPublishLink {
+    pub document_id: u32,
     pub link_id: [u8; 16],
     pub calendar_id: u32,
     pub access: PublishAccess,
@@ -82,6 +83,7 @@ impl PublishLinkSecret {
 
 impl CalendarPublishLink {
     pub fn new(
+        document_id: u32,
         calendar_id: u32,
         access: PublishAccess,
         visibility: PublishVisibility,
@@ -91,6 +93,7 @@ impl CalendarPublishLink {
         expires_at: Option<i64>,
     ) -> Self {
         CalendarPublishLink {
+            document_id,
             link_id: rand::random(),
             calendar_id,
             access,

--- a/crates/http/src/ics.rs
+++ b/crates/http/src/ics.rs
@@ -5,13 +5,22 @@
  */
 
 use common::Server;
-use dav_proto::schema::property::Rfc1123DateTime;
 use groupware::calendar::{
     publish_http::{CalendarPublishStore, parse_ics_http_path},
 };
 use http_proto::HttpResponse;
 use hyper::{header, StatusCode};
+use trc::AddContext;
 use utils::cheeky_hash::CheekyHash;
+
+fn http_date(timestamp: i64) -> String {
+    chrono::DateTime::from_timestamp(timestamp, 0)
+        .map(|dt| {
+            dt.format("%a, %d %b %Y %H:%M:%S GMT")
+                .to_string()
+        })
+        .unwrap_or_default()
+}
 
 pub trait IcsHttpHandler: Sync + Send {
     fn http_ics_handle(
@@ -39,10 +48,10 @@ impl IcsHttpHandler for Server {
             .await
             .caused_by(trc::location!())?;
 
-        let mut response = HttpResponse::new(StatusCode::OK)
+        let response = HttpResponse::new(StatusCode::OK)
             .with_content_type("text/calendar; charset=utf-8")
             .with_etag(etag)
-            .with_last_modified(Rfc1123DateTime::new(last_modified).to_string())
+            .with_last_modified(http_date(last_modified))
             .with_header(header::CACHE_CONTROL, "private, max-age=300")
             .with_header("X-Robots-Tag", "noindex");
 

--- a/crates/http/src/ics.rs
+++ b/crates/http/src/ics.rs
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+use common::Server;
+use dav_proto::schema::property::Rfc1123DateTime;
+use groupware::calendar::{
+    publish_http::{CalendarPublishStore, parse_ics_http_path},
+};
+use http_proto::HttpResponse;
+use hyper::{header, StatusCode};
+use utils::cheeky_hash::CheekyHash;
+use utils::cheeky_hash::CheekyHash;
+
+pub trait IcsHttpHandler: Sync + Send {
+    fn http_ics_handle(
+        &self,
+        path: &str,
+        is_head: bool,
+    ) -> impl Future<Output = trc::Result<HttpResponse>> + Send;
+}
+
+impl IcsHttpHandler for Server {
+    async fn http_ics_handle(&self, path: &str, is_head: bool) -> trc::Result<HttpResponse> {
+        let (link_id, secret, is_public) = parse_ics_http_path(path)?;
+        let (account_id, link) = self
+            .verify_publish_link_access(link_id, secret.as_deref(), is_public)
+            .await?;
+
+        let ical_body = self.export_calendar_publish_feed(account_id, &link).await?;
+        let etag = format!(
+            "\"{}\"",
+            CheekyHash::new(ical_body.as_bytes()).to_string()
+        );
+        let last_modified = link.last_used_at.unwrap_or(link.created_at);
+
+        self.touch_publish_link_if_stale(account_id, &link)
+            .await
+            .caused_by(trc::location!())?;
+
+        let mut response = HttpResponse::new(StatusCode::OK)
+            .with_content_type("text/calendar; charset=utf-8")
+            .with_etag(etag)
+            .with_last_modified(Rfc1123DateTime::new(last_modified).to_string())
+            .with_header(header::CACHE_CONTROL, "private, max-age=300")
+            .with_header("X-Robots-Tag", "noindex");
+
+        if is_head {
+            Ok(response.with_content_length(ical_body.len()))
+        } else {
+            Ok(response.with_binary_body(ical_body))
+        }
+    }
+}

--- a/crates/http/src/ics.rs
+++ b/crates/http/src/ics.rs
@@ -12,7 +12,6 @@ use groupware::calendar::{
 use http_proto::HttpResponse;
 use hyper::{header, StatusCode};
 use utils::cheeky_hash::CheekyHash;
-use utils::cheeky_hash::CheekyHash;
 
 pub trait IcsHttpHandler: Sync + Send {
     fn http_ics_handle(

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod api;
 pub mod auth;
 pub mod form;
+pub mod ics;
 pub mod request;
 
 use common::Inner;

--- a/crates/http/src/request.rs
+++ b/crates/http/src/request.rs
@@ -450,6 +450,26 @@ impl ParseHttp for Server {
                 }
             }
             "ics" => {
+                // Prefer an operator-registered WebApplication at "/ics" (if any) so this
+                // built-in route never permanently shadows a pre-existing custom mount.
+                if let Some(resource) = self
+                    .inner
+                    .data
+                    .applications
+                    .serve(
+                        "ics",
+                        req.uri().path().get("ics".len() + 2..).unwrap_or_default(),
+                    )
+                    .await?
+                {
+                    let response = resource.resource.into_http_response();
+                    return Ok(if !resource.no_cache {
+                        response.with_immutable_cache()
+                    } else {
+                        response.with_no_cache()
+                    });
+                }
+
                 self.is_http_anonymous_request_allowed(session.remote_ip)
                     .await?;
 

--- a/crates/http/src/request.rs
+++ b/crates/http/src/request.rs
@@ -453,7 +453,7 @@ impl ParseHttp for Server {
                 self.is_http_anonymous_request_allowed(session.remote_ip)
                     .await?;
 
-                if matches!(req.method(), Method::GET | Method::HEAD) {
+                if req.method() == Method::GET || req.method() == Method::HEAD {
                     let mut segments = Vec::new();
                     while let Some(p) = path.next() {
                         if !p.is_empty() {
@@ -463,8 +463,7 @@ impl ParseHttp for Server {
                     let subpath = segments.join("/");
                     return self
                         .http_ics_handle(&subpath, req.method() == Method::HEAD)
-                        .await
-                        .map(|response| response.into_http_response());
+                        .await;
                 }
             }
             "calendar" => {

--- a/crates/http/src/request.rs
+++ b/crates/http/src/request.rs
@@ -23,6 +23,7 @@ use common::{
     network::{SessionData, SessionManager, SessionStream},
 };
 use dav::{DavMethod, request::DavRequestHandler};
+use crate::ics::IcsHttpHandler;
 use groupware::{DavResourceName, calendar::itip::ItipIngest};
 use http_proto::{
     DownloadResponse, HtmlResponse, HttpContext, HttpRequest, HttpResponse, HttpResponseBody,
@@ -446,6 +447,24 @@ impl ParseHttp for Server {
                         .handle_autoconfig_request(req.uri().query())
                         .await
                         .map(|resource| resource.into_http_response());
+                }
+            }
+            "ics" => {
+                self.is_http_anonymous_request_allowed(session.remote_ip)
+                    .await?;
+
+                if matches!(req.method(), Method::GET | Method::HEAD) {
+                    let mut segments = Vec::new();
+                    while let Some(p) = path.next() {
+                        if !p.is_empty() {
+                            segments.push(p);
+                        }
+                    }
+                    let subpath = segments.join("/");
+                    return self
+                        .http_ics_handle(&subpath, req.method() == Method::HEAD)
+                        .await
+                        .map(|response| response.into_http_response());
                 }
             }
             "calendar" => {

--- a/crates/jmap-proto/src/object/calendar_publish_link.rs
+++ b/crates/jmap-proto/src/object/calendar_publish_link.rs
@@ -31,20 +31,20 @@ pub enum CalendarPublishLinkProperty {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CalendarPublishLinkValue {
-    Id(String),
+    Id(Id),
     CalendarId(Id),
     Access(PublishAccess),
     Visibility(PublishVisibility),
     Date(UTCDate),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PublishAccess {
     Public,
     Private,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PublishVisibility {
     Full,
     Busy,
@@ -105,7 +105,7 @@ impl Element for CalendarPublishLinkValue {
 
     fn to_cow(&self) -> Cow<'static, str> {
         match self {
-            CalendarPublishLinkValue::Id(id) => id.clone().into(),
+            CalendarPublishLinkValue::Id(id) => id.as_string().into(),
             CalendarPublishLinkValue::CalendarId(id) => id.to_string().into(),
             CalendarPublishLinkValue::Access(a) => match a {
                 PublishAccess::Public => "public",
@@ -150,7 +150,7 @@ impl FromStr for CalendarPublishLinkProperty {
 impl JmapObject for CalendarPublishLink {
     type Property = CalendarPublishLinkProperty;
     type Element = CalendarPublishLinkValue;
-    type Id = String;
+    type Id = Id;
     type Filter = ();
     type Comparator = ();
     type GetArguments = ();
@@ -161,48 +161,33 @@ impl JmapObject for CalendarPublishLink {
     const ID_PROPERTY: Self::Property = CalendarPublishLinkProperty::Id;
 }
 
-impl From<String> for CalendarPublishLinkValue {
-    fn from(id: String) -> Self {
-        CalendarPublishLinkValue::Id(id)
-    }
-}
-
 impl From<Id> for CalendarPublishLinkValue {
     fn from(id: Id) -> Self {
         CalendarPublishLinkValue::CalendarId(id)
     }
 }
 
-impl TryFrom<AnyId> for String {
-    type Error = ();
-
-    fn try_from(_: AnyId) -> Result<Self, Self::Error> {
-        Err(())
+impl From<String> for CalendarPublishLinkValue {
+    fn from(_: String) -> Self {
+        unreachable!("CalendarPublishLink ids are JMAP Id values")
     }
 }
 
 impl JmapObjectId for CalendarPublishLinkValue {
     fn as_id(&self) -> Option<Id> {
         match self {
+            CalendarPublishLinkValue::Id(id) => Some(*id),
             CalendarPublishLinkValue::CalendarId(id) => Some(*id),
             _ => None,
         }
     }
 
     fn as_any_id(&self) -> Option<AnyId> {
-        if let CalendarPublishLinkValue::CalendarId(id) = self {
-            Some(AnyId::Id(*id))
-        } else {
-            None
-        }
+        self.as_id().map(AnyId::Id)
     }
 
     fn as_id_ref(&self) -> Option<&str> {
-        if let CalendarPublishLinkValue::Id(id) = self {
-            Some(id)
-        } else {
-            None
-        }
+        None
     }
 
     fn try_set_id(&mut self, id: AnyId) -> bool {

--- a/crates/jmap-proto/src/object/calendar_publish_link.rs
+++ b/crates/jmap-proto/src/object/calendar_publish_link.rs
@@ -1,0 +1,262 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+use crate::{
+    object::{AnyId, JmapObject, JmapObjectId},
+    types::date::UTCDate,
+};
+use jmap_tools::{Element, Key, Property};
+use std::{borrow::Cow, fmt::Display, str::FromStr};
+use types::id::Id;
+
+#[derive(Debug, Clone, Default)]
+pub struct CalendarPublishLink;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalendarPublishLinkProperty {
+    Id,
+    CalendarId,
+    Access,
+    Visibility,
+    Label,
+    Url,
+    Secret,
+    CreatedAt,
+    LastUsedAt,
+    ExpiresAt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalendarPublishLinkValue {
+    Id(String),
+    CalendarId(Id),
+    Access(PublishAccess),
+    Visibility(PublishVisibility),
+    Date(UTCDate),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishAccess {
+    Public,
+    Private,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishVisibility {
+    Full,
+    Busy,
+}
+
+impl Property for CalendarPublishLinkProperty {
+    fn try_parse(_: Option<&Key<'_, Self>>, value: &str) -> Option<Self> {
+        CalendarPublishLinkProperty::parse(value)
+    }
+
+    fn to_cow(&self) -> Cow<'static, str> {
+        match self {
+            CalendarPublishLinkProperty::Id => "id",
+            CalendarPublishLinkProperty::CalendarId => "calendarId",
+            CalendarPublishLinkProperty::Access => "access",
+            CalendarPublishLinkProperty::Visibility => "visibility",
+            CalendarPublishLinkProperty::Label => "label",
+            CalendarPublishLinkProperty::Url => "url",
+            CalendarPublishLinkProperty::Secret => "secret",
+            CalendarPublishLinkProperty::CreatedAt => "createdAt",
+            CalendarPublishLinkProperty::LastUsedAt => "lastUsedAt",
+            CalendarPublishLinkProperty::ExpiresAt => "expiresAt",
+        }
+        .into()
+    }
+}
+
+impl Element for CalendarPublishLinkValue {
+    type Property = CalendarPublishLinkProperty;
+
+    fn try_parse<P>(key: &Key<'_, Self::Property>, value: &str) -> Option<Self> {
+        if let Key::Property(prop) = key {
+            match prop {
+                CalendarPublishLinkProperty::CalendarId => {
+                    Id::from_str(value).ok().map(CalendarPublishLinkValue::CalendarId)
+                }
+                CalendarPublishLinkProperty::Access => match value {
+                    "public" => Some(CalendarPublishLinkValue::Access(PublishAccess::Public)),
+                    "private" => Some(CalendarPublishLinkValue::Access(PublishAccess::Private)),
+                    _ => None,
+                },
+                CalendarPublishLinkProperty::Visibility => match value {
+                    "full" => Some(CalendarPublishLinkValue::Visibility(PublishVisibility::Full)),
+                    "busy" => Some(CalendarPublishLinkValue::Visibility(PublishVisibility::Busy)),
+                    _ => None,
+                },
+                CalendarPublishLinkProperty::CreatedAt
+                | CalendarPublishLinkProperty::LastUsedAt
+                | CalendarPublishLinkProperty::ExpiresAt => UTCDate::from_str(value)
+                    .ok()
+                    .map(CalendarPublishLinkValue::Date),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    fn to_cow(&self) -> Cow<'static, str> {
+        match self {
+            CalendarPublishLinkValue::Id(id) => id.clone().into(),
+            CalendarPublishLinkValue::CalendarId(id) => id.to_string().into(),
+            CalendarPublishLinkValue::Access(a) => match a {
+                PublishAccess::Public => "public",
+                PublishAccess::Private => "private",
+            }
+            .into(),
+            CalendarPublishLinkValue::Visibility(v) => match v {
+                PublishVisibility::Full => "full",
+                PublishVisibility::Busy => "busy",
+            }
+            .into(),
+            CalendarPublishLinkValue::Date(d) => d.to_string().into(),
+        }
+    }
+}
+
+impl CalendarPublishLinkProperty {
+    fn parse(value: &str) -> Option<Self> {
+        hashify::tiny_map!(value.as_bytes(),
+            b"id" => CalendarPublishLinkProperty::Id,
+            b"calendarId" => CalendarPublishLinkProperty::CalendarId,
+            b"access" => CalendarPublishLinkProperty::Access,
+            b"visibility" => CalendarPublishLinkProperty::Visibility,
+            b"label" => CalendarPublishLinkProperty::Label,
+            b"url" => CalendarPublishLinkProperty::Url,
+            b"secret" => CalendarPublishLinkProperty::Secret,
+            b"createdAt" => CalendarPublishLinkProperty::CreatedAt,
+            b"lastUsedAt" => CalendarPublishLinkProperty::LastUsedAt,
+            b"expiresAt" => CalendarPublishLinkProperty::ExpiresAt
+        )
+    }
+}
+
+impl FromStr for CalendarPublishLinkProperty {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        CalendarPublishLinkProperty::parse(s).ok_or(())
+    }
+}
+
+impl JmapObject for CalendarPublishLink {
+    type Property = CalendarPublishLinkProperty;
+    type Element = CalendarPublishLinkValue;
+    type Id = String;
+    type Filter = ();
+    type Comparator = ();
+    type GetArguments = ();
+    type SetArguments<'de> = ();
+    type QueryArguments = ();
+    type CopyArguments = ();
+    type ParseArguments = ();
+    const ID_PROPERTY: Self::Property = CalendarPublishLinkProperty::Id;
+}
+
+impl From<String> for CalendarPublishLinkValue {
+    fn from(id: String) -> Self {
+        CalendarPublishLinkValue::Id(id)
+    }
+}
+
+impl From<Id> for CalendarPublishLinkValue {
+    fn from(id: Id) -> Self {
+        CalendarPublishLinkValue::CalendarId(id)
+    }
+}
+
+impl TryFrom<AnyId> for String {
+    type Error = ();
+
+    fn try_from(_: AnyId) -> Result<Self, Self::Error> {
+        Err(())
+    }
+}
+
+impl JmapObjectId for CalendarPublishLinkValue {
+    fn as_id(&self) -> Option<Id> {
+        match self {
+            CalendarPublishLinkValue::CalendarId(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    fn as_any_id(&self) -> Option<AnyId> {
+        if let CalendarPublishLinkValue::CalendarId(id) = self {
+            Some(AnyId::Id(*id))
+        } else {
+            None
+        }
+    }
+
+    fn as_id_ref(&self) -> Option<&str> {
+        if let CalendarPublishLinkValue::Id(id) = self {
+            Some(id)
+        } else {
+            None
+        }
+    }
+
+    fn try_set_id(&mut self, id: AnyId) -> bool {
+        let _ = id;
+        false
+    }
+}
+
+impl JmapObjectId for CalendarPublishLinkProperty {
+    fn as_id(&self) -> Option<Id> {
+        None
+    }
+
+    fn as_any_id(&self) -> Option<AnyId> {
+        None
+    }
+
+    fn as_id_ref(&self) -> Option<&str> {
+        None
+    }
+
+    fn try_set_id(&mut self, _: AnyId) -> bool {
+        false
+    }
+}
+
+impl Display for CalendarPublishLinkProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_cow())
+    }
+}
+
+impl Display for PublishAccess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PublishAccess::Public => "public",
+                PublishAccess::Private => "private",
+            }
+        )
+    }
+}
+
+impl Display for PublishVisibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PublishVisibility::Full => "full",
+                PublishVisibility::Busy => "busy",
+            }
+        )
+    }
+}

--- a/crates/jmap-proto/src/object/mod.rs
+++ b/crates/jmap-proto/src/object/mod.rs
@@ -15,6 +15,7 @@ pub mod blob;
 pub mod calendar;
 pub mod calendar_event;
 pub mod calendar_event_notification;
+pub mod calendar_publish_link;
 pub mod contact;
 pub mod email;
 pub mod email_submission;

--- a/crates/jmap-proto/src/references/eval.rs
+++ b/crates/jmap-proto/src/references/eval.rs
@@ -81,6 +81,9 @@ impl Response<'_> {
                         GetResponseMethod::ShareNotification(response) => {
                             response.eval_jptr(path, &mut results)
                         }
+                        GetResponseMethod::CalendarPublishLink(response) => {
+                            response.eval_jptr(path, &mut results)
+                        }
                         GetResponseMethod::PrincipalAvailability(response) => {
                             response.eval_jptr(path, &mut results)
                         }

--- a/crates/jmap-proto/src/references/resolve.rs
+++ b/crates/jmap-proto/src/references/resolve.rs
@@ -48,6 +48,9 @@ impl Response<'_> {
                 GetRequestMethod::ContactCard(request) => request.resolve_references(self)?,
                 GetRequestMethod::FileNode(request) => request.resolve_references(self)?,
                 GetRequestMethod::ShareNotification(request) => request.resolve_references(self)?,
+                GetRequestMethod::CalendarPublishLink(request) => {
+                    request.resolve_references(self)?
+                }
                 GetRequestMethod::Calendar(request) => request.resolve_references(self)?,
                 GetRequestMethod::CalendarEvent(request) => request.resolve_references(self)?,
                 GetRequestMethod::CalendarEventNotification(request) => {
@@ -85,6 +88,9 @@ impl Response<'_> {
                     request.resolve_references(self, 1, false)?
                 }
                 SetRequestMethod::ShareNotification(request) => {
+                    request.resolve_references(self, 1, false)?
+                }
+                SetRequestMethod::CalendarPublishLink(request) => {
                     request.resolve_references(self, 1, false)?
                 }
                 SetRequestMethod::Calendar(request) => {

--- a/crates/jmap-proto/src/request/method.rs
+++ b/crates/jmap-proto/src/request/method.rs
@@ -40,6 +40,7 @@ pub enum MethodObject {
     FileNode,
     ParticipantIdentity,
     ShareNotification,
+    CalendarPublishLink,
     Registry(ObjectType),
 }
 
@@ -60,7 +61,8 @@ impl MethodObject {
             MethodObject::Calendar
             | MethodObject::CalendarEvent
             | MethodObject::CalendarEventNotification
-            | MethodObject::ParticipantIdentity => Capability::Calendars,
+            | MethodObject::ParticipantIdentity
+            | MethodObject::CalendarPublishLink => Capability::Calendars,
             MethodObject::AddressBook | MethodObject::ContactCard => Capability::Contacts,
             MethodObject::FileNode => Capability::FileNode,
             MethodObject::Registry(_) => Capability::Stalwart,
@@ -234,6 +236,9 @@ impl MethodName {
             }
             (MethodFunction::Set, MethodObject::ParticipantIdentity) => "ParticipantIdentity/set",
 
+            (MethodFunction::Get, MethodObject::CalendarPublishLink) => "CalendarPublishLink/get",
+            (MethodFunction::Set, MethodObject::CalendarPublishLink) => "CalendarPublishLink/set",
+
             (MethodFunction::Echo, MethodObject::Core) => "Core/echo",
             (method, MethodObject::Registry(obj)) => {
                 return Cow::Owned(format!("x:{}/{}", obj.as_str(), method.as_str()));
@@ -352,6 +357,9 @@ impl MethodName {
             "ParticipantIdentity/changes" => (MethodObject::ParticipantIdentity, MethodFunction::Changes),
             "ParticipantIdentity/set" => (MethodObject::ParticipantIdentity, MethodFunction::Set),
 
+            "CalendarPublishLink/get" => (MethodObject::CalendarPublishLink, MethodFunction::Get),
+            "CalendarPublishLink/set" => (MethodObject::CalendarPublishLink, MethodFunction::Set),
+
             "Core/echo" => (MethodObject::Core, MethodFunction::Echo),
 
         ).or_else(|| {
@@ -396,6 +404,7 @@ impl Display for MethodObject {
             MethodObject::CalendarEvent => "CalendarEvent",
             MethodObject::CalendarEventNotification => "CalendarEventNotification",
             MethodObject::ShareNotification => "ShareNotification",
+            MethodObject::CalendarPublishLink => "CalendarPublishLink",
             MethodObject::Registry(obj) => {
                 f.write_str("x:")?;
                 return f.write_str(obj.as_str());

--- a/crates/jmap-proto/src/request/mod.rs
+++ b/crates/jmap-proto/src/request/mod.rs
@@ -35,6 +35,7 @@ use crate::{
         identity::Identity, mailbox::Mailbox, participant_identity::ParticipantIdentity,
         principal::Principal, push_subscription::PushSubscription, quota::Quota,
         registry::Registry, share_notification::ShareNotification, sieve::Sieve, thread::Thread,
+        calendar_publish_link::CalendarPublishLink,
         vacation_response::VacationResponse,
     },
     request::{capability::CapabilityIds, reference::MaybeIdReference},
@@ -110,6 +111,7 @@ pub enum GetRequestMethod {
     CalendarEventNotification(Box<GetRequest<CalendarEventNotification>>),
     ParticipantIdentity(Box<GetRequest<ParticipantIdentity>>),
     ShareNotification(Box<GetRequest<ShareNotification>>),
+    CalendarPublishLink(Box<GetRequest<CalendarPublishLink>>),
     Registry(Box<GetRequest<Registry>>),
 }
 
@@ -130,6 +132,7 @@ pub enum SetRequestMethod<'x> {
     CalendarEvent(Box<SetRequest<'x, CalendarEvent>>),
     CalendarEventNotification(Box<SetRequest<'x, CalendarEventNotification>>),
     ParticipantIdentity(Box<SetRequest<'x, ParticipantIdentity>>),
+    CalendarPublishLink(Box<SetRequest<'x, CalendarPublishLink>>),
     Registry(Box<SetRequest<'x, Registry>>),
 }
 

--- a/crates/jmap-proto/src/request/parser.rs
+++ b/crates/jmap-proto/src/request/parser.rs
@@ -241,6 +241,15 @@ impl<'de> Visitor<'de> for CallVisitor {
                     return Err(de::Error::invalid_length(1, &self));
                 }
             },
+            (MethodFunction::Get, MethodObject::CalendarPublishLink) => match seq.next_element() {
+                Ok(Some(value)) => {
+                    RequestMethod::Get(GetRequestMethod::CalendarPublishLink(value))
+                }
+                Err(err) => RequestMethod::invalid(err),
+                Ok(None) => {
+                    return Err(de::Error::invalid_length(1, &self));
+                }
+            },
             (MethodFunction::Get, MethodObject::SearchSnippet) => match seq.next_element() {
                 Ok(Some(value)) => RequestMethod::SearchSnippet(value),
                 Err(err) => RequestMethod::invalid(err),
@@ -359,6 +368,15 @@ impl<'de> Visitor<'de> for CallVisitor {
             },
             (MethodFunction::Set, MethodObject::ShareNotification) => match seq.next_element() {
                 Ok(Some(value)) => RequestMethod::Set(SetRequestMethod::ShareNotification(value)),
+                Err(err) => RequestMethod::invalid(err),
+                Ok(None) => {
+                    return Err(de::Error::invalid_length(1, &self));
+                }
+            },
+            (MethodFunction::Set, MethodObject::CalendarPublishLink) => match seq.next_element() {
+                Ok(Some(value)) => {
+                    RequestMethod::Set(SetRequestMethod::CalendarPublishLink(value))
+                }
                 Err(err) => RequestMethod::invalid(err),
                 Ok(None) => {
                     return Err(de::Error::invalid_length(1, &self));

--- a/crates/jmap-proto/src/response/mod.rs
+++ b/crates/jmap-proto/src/response/mod.rs
@@ -46,6 +46,7 @@ use crate::{
         quota::Quota,
         registry::Registry,
         share_notification::ShareNotification,
+        calendar_publish_link::CalendarPublishLink,
         sieve::Sieve,
         thread::Thread,
         vacation_response::VacationResponse,
@@ -97,6 +98,7 @@ pub enum GetResponseMethod {
     CalendarEventNotification(CalendarEventNotificationGetResponse),
     ParticipantIdentity(GetResponse<ParticipantIdentity>),
     ShareNotification(GetResponse<ShareNotification>),
+    CalendarPublishLink(GetResponse<CalendarPublishLink>),
     Registry(GetResponse<Registry>),
 }
 
@@ -118,6 +120,7 @@ pub enum SetResponseMethod {
     CalendarEvent(Box<SetResponse<CalendarEvent>>),
     CalendarEventNotification(Box<SetResponse<CalendarEventNotification>>),
     ParticipantIdentity(Box<SetResponse<ParticipantIdentity>>),
+    CalendarPublishLink(Box<SetResponse<CalendarPublishLink>>),
     Registry(Box<SetResponse<Registry>>),
 }
 
@@ -571,9 +574,21 @@ impl From<SetResponse<ShareNotification>> for ResponseMethod<'_> {
     }
 }
 
+impl From<SetResponse<CalendarPublishLink>> for ResponseMethod<'_> {
+    fn from(response: SetResponse<CalendarPublishLink>) -> Self {
+        ResponseMethod::Set(SetResponseMethod::CalendarPublishLink(Box::new(response)))
+    }
+}
+
 impl From<GetResponse<ShareNotification>> for ResponseMethod<'_> {
     fn from(response: GetResponse<ShareNotification>) -> Self {
         ResponseMethod::Get(GetResponseMethod::ShareNotification(response))
+    }
+}
+
+impl From<GetResponse<CalendarPublishLink>> for ResponseMethod<'_> {
+    fn from(response: GetResponse<CalendarPublishLink>) -> Self {
+        ResponseMethod::Get(GetResponseMethod::CalendarPublishLink(response))
     }
 }
 

--- a/crates/jmap/src/api/auth.rs
+++ b/crates/jmap/src/api/auth.rs
@@ -85,6 +85,7 @@ impl JmapAuthorization for AccessToken {
                 }
                 GetRequestMethod::ParticipantIdentity(_) => Permission::JmapParticipantIdentityGet,
                 GetRequestMethod::ShareNotification(_) => Permission::JmapShareNotificationGet,
+                GetRequestMethod::CalendarPublishLink(_) => Permission::JmapCalendarGet,
                 GetRequestMethod::Registry(_) => {
                     let MethodObject::Registry(object_type) = object else {
                         unreachable!()
@@ -198,6 +199,13 @@ impl JmapAuthorization for AccessToken {
                         Permission::JmapParticipantIdentityCreate,
                         Permission::JmapParticipantIdentityUpdate,
                         Permission::JmapParticipantIdentityDestroy,
+                    ),
+                    SetRequestMethod::CalendarPublishLink(s) => validate_set(
+                        s,
+                        self,
+                        Permission::JmapCalendarCreate,
+                        Permission::JmapCalendarUpdate,
+                        Permission::JmapCalendarDestroy,
                     ),
                     SetRequestMethod::Registry(s) => {
                         let MethodObject::Registry(object_type) = object else {

--- a/crates/jmap/src/api/auth.rs
+++ b/crates/jmap/src/api/auth.rs
@@ -238,6 +238,7 @@ impl JmapAuthorization for AccessToken {
                 }
                 MethodObject::ParticipantIdentity => Permission::JmapParticipantIdentityChanges,
                 MethodObject::ShareNotification => Permission::JmapShareNotificationChanges,
+                MethodObject::CalendarPublishLink => Permission::JmapCalendarChanges,
                 MethodObject::Principal => Permission::JmapPrincipalChanges,
                 MethodObject::AddressBook => Permission::JmapAddressBookChanges,
                 MethodObject::Core

--- a/crates/jmap/src/api/request.rs
+++ b/crates/jmap/src/api/request.rs
@@ -373,7 +373,7 @@ impl RequestHandler for Server {
                     resolve_account_id(&mut req.account_id, method_name.obj, access_token)?;
                     access_token.assert_has_access(req.account_id, Collection::Calendar)?;
 
-                    self.calendar_publish_link_get(*req).await?.into()
+                    self.calendar_publish_link_get(*req, access_token).await?.into()
                 }
                 GetRequestMethod::Registry(mut req) => {
                     resolve_account_id(&mut req.account_id, method_name.obj, access_token)?;

--- a/crates/jmap/src/api/request.rs
+++ b/crates/jmap/src/api/request.rs
@@ -17,6 +17,7 @@ use crate::{
         get::CalendarEventNotificationGet, query::CalendarEventNotificationQuery,
         set::CalendarEventNotificationSet,
     },
+    calendar_publish_link::{get::CalendarPublishLinkGet, set::CalendarPublishLinkSet},
     changes::{get::ChangesLookup, query::QueryChanges},
     contact::{
         copy::JmapContactCardCopy, get::ContactCardGet, parse::ContactCardParse,
@@ -181,6 +182,9 @@ impl RequestHandler for Server {
                                         set_response.update_created_ids(&mut response);
                                     }
                                     SetResponseMethod::ParticipantIdentity(set_response) => {
+                                        set_response.update_created_ids(&mut response);
+                                    }
+                                    SetResponseMethod::CalendarPublishLink(set_response) => {
                                         set_response.update_created_ids(&mut response);
                                     }
                                     SetResponseMethod::CalendarEventNotification(_) => {}
@@ -364,6 +368,12 @@ impl RequestHandler for Server {
                     access_token.assert_is_member(req.account_id)?;
 
                     self.share_notification_get(*req).await?.into()
+                }
+                GetRequestMethod::CalendarPublishLink(mut req) => {
+                    resolve_account_id(&mut req.account_id, method_name.obj, access_token)?;
+                    access_token.assert_has_access(req.account_id, Collection::Calendar)?;
+
+                    self.calendar_publish_link_get(*req).await?.into()
                 }
                 GetRequestMethod::Registry(mut req) => {
                     resolve_account_id(&mut req.account_id, method_name.obj, access_token)?;
@@ -571,6 +581,12 @@ impl RequestHandler for Server {
                     access_token.assert_is_member(req.account_id)?;
 
                     self.participant_identity_set(*req).await?.into()
+                }
+                SetRequestMethod::CalendarPublishLink(mut req) => {
+                    resolve_account_id(&mut req.account_id, method_name.obj, access_token)?;
+                    access_token.assert_has_access(req.account_id, Collection::Calendar)?;
+
+                    self.calendar_publish_link_set(*req, access_token).await?.into()
                 }
                 SetRequestMethod::Registry(mut req) => {
                     resolve_account_id(&mut req.account_id, method_name.obj, access_token)?;

--- a/crates/jmap/src/calendar/set.rs
+++ b/crates/jmap/src/calendar/set.rs
@@ -15,6 +15,7 @@ use groupware::{
         ALERT_EMAIL, ALERT_RELATIVE_TO_END, ALERT_WITH_TIME, CALENDAR_AVAILABILITY_ALL,
         CALENDAR_AVAILABILITY_ATTENDING, CALENDAR_AVAILABILITY_NONE, CALENDAR_INVISIBLE,
         CALENDAR_SUBSCRIBED, Calendar, CalendarEvent, CalendarPreferences, DefaultAlert, Timezone,
+        publish_http::{CalendarPublishStore, clear_publish_link},
     },
 };
 use http_proto::HttpSessionData;
@@ -239,6 +240,10 @@ impl CalendarSet for Server {
                 .caused_by(trc::location!())?;
             let on_destroy_remove_events =
                 request.arguments.on_destroy_remove_events.unwrap_or(false);
+            let publish_links = self
+                .list_publish_links(account_id)
+                .await
+                .caused_by(trc::location!())?;
             for id in will_destroy {
                 let document_id = id.document_id();
 
@@ -308,6 +313,12 @@ impl CalendarSet for Server {
 
                 if default_calendar_id == Some(document_id) {
                     reset_default_calendar = true;
+                }
+
+                // Revoke any ICS publish links for this calendar so their secrets
+                // don't keep serving data after the calendar itself is gone.
+                for link in publish_links.iter().filter(|l| l.calendar_id == document_id) {
+                    clear_publish_link(&mut batch, account_id, link.link_id);
                 }
 
                 response.destroyed.push(id);

--- a/crates/jmap/src/calendar_publish_link/get.rs
+++ b/crates/jmap/src/calendar_publish_link/get.rs
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+use common::Server;
+use groupware::calendar::publish_link::format_uuid;
+use jmap_proto::{
+    method::get::{GetRequest, GetResponse},
+    object::calendar_publish_link::{
+        self, CalendarPublishLinkProperty, CalendarPublishLinkValue, PublishAccess,
+        PublishVisibility,
+    },
+    request::IntoValid,
+};
+use jmap_tools::{Map, Value};
+use trc::AddContext;
+use types::id::Id;
+
+pub trait CalendarPublishLinkGet: Sync + Send {
+    fn calendar_publish_link_get(
+        &self,
+        request: GetRequest<calendar_publish_link::CalendarPublishLink>,
+    ) -> impl Future<Output = trc::Result<GetResponse<calendar_publish_link::CalendarPublishLink>>> + Send;
+}
+
+impl CalendarPublishLinkGet for Server {
+    async fn calendar_publish_link_get(
+        &self,
+        mut request: GetRequest<calendar_publish_link::CalendarPublishLink>,
+    ) -> trc::Result<GetResponse<calendar_publish_link::CalendarPublishLink>> {
+        let properties = request.unwrap_properties(&[
+            CalendarPublishLinkProperty::Id,
+            CalendarPublishLinkProperty::CalendarId,
+            CalendarPublishLinkProperty::Access,
+            CalendarPublishLinkProperty::Visibility,
+            CalendarPublishLinkProperty::Label,
+            CalendarPublishLinkProperty::Url,
+            CalendarPublishLinkProperty::CreatedAt,
+            CalendarPublishLinkProperty::LastUsedAt,
+            CalendarPublishLinkProperty::ExpiresAt,
+        ]);
+
+        let account_id = request.account_id.document_id();
+        let filter_ids = request
+            .ids
+            .take()
+            .map(|ids| {
+                ids.unwrap()
+                    .into_valid()
+                    .map(|id| id.as_ref().to_string())
+                    .collect::<std::collections::HashSet<_>>()
+            });
+
+        let links = self.list_publish_links(account_id).await?;
+        let mut response = GetResponse {
+            account_id: request.account_id.into(),
+            state: None,
+            list: Vec::new(),
+            not_found: vec![],
+        };
+
+        for link in links {
+            let id = format_uuid(&link.link_id);
+            if filter_ids.as_ref().is_some_and(|ids| !ids.contains(&id)) {
+                continue;
+            }
+            if response.list.len() >= self.core.jmap.get_max_objects {
+                break;
+            }
+            response.list.push(build_publish_link_object(
+                &link,
+                &properties,
+                self.build_publish_url(&link, None),
+            ));
+        }
+
+        if let Some(ids) = filter_ids {
+            for id in ids {
+                if !links.iter().any(|l| format_uuid(&l.link_id) == id) {
+                    response.not_found.push(id);
+                }
+            }
+        }
+
+        Ok(response)
+    }
+}
+
+fn build_publish_link_object(
+    link: &groupware::calendar::publish_link::CalendarPublishLink,
+    properties: &[CalendarPublishLinkProperty],
+    url: String,
+) -> Value<'static, CalendarPublishLinkProperty, CalendarPublishLinkValue> {
+    let id = format_uuid(&link.link_id);
+    let mut result = Map::with_capacity(properties.len());
+    for property in properties {
+        let value = match property {
+            CalendarPublishLinkProperty::Id => {
+                Value::Element(CalendarPublishLinkValue::Id(id.clone()))
+            }
+            CalendarPublishLinkProperty::CalendarId => Value::Element(
+                CalendarPublishLinkValue::CalendarId(Id::from(link.calendar_id)),
+            ),
+            CalendarPublishLinkProperty::Access => Value::Element(
+                CalendarPublishLinkValue::Access(match link.access {
+                    groupware::calendar::publish_link::PublishAccess::Public => PublishAccess::Public,
+                    groupware::calendar::publish_link::PublishAccess::Private => {
+                        PublishAccess::Private
+                    }
+                }),
+            ),
+            CalendarPublishLinkProperty::Visibility => Value::Element(
+                CalendarPublishLinkValue::Visibility(match link.visibility {
+                    groupware::calendar::publish_link::PublishVisibility::Full => {
+                        PublishVisibility::Full
+                    }
+                    groupware::calendar::publish_link::PublishVisibility::Busy => {
+                        PublishVisibility::Busy
+                    }
+                }),
+            ),
+            CalendarPublishLinkProperty::Label => {
+                Value::Str(link.label.clone().unwrap_or_default().into())
+            }
+            CalendarPublishLinkProperty::Url => Value::Str(url.clone().into()),
+            CalendarPublishLinkProperty::CreatedAt => Value::Element(
+                CalendarPublishLinkValue::Date(jmap_proto::types::date::UTCDate::from_timestamp(
+                    link.created_at,
+                )),
+            ),
+            CalendarPublishLinkProperty::LastUsedAt => link
+                .last_used_at
+                .map(|ts| {
+                    Value::Element(CalendarPublishLinkValue::Date(
+                        jmap_proto::types::date::UTCDate::from_timestamp(ts),
+                    ))
+                })
+                .unwrap_or(Value::Null),
+            CalendarPublishLinkProperty::ExpiresAt => link
+                .expires_at
+                .map(|ts| {
+                    Value::Element(CalendarPublishLinkValue::Date(
+                        jmap_proto::types::date::UTCDate::from_timestamp(ts),
+                    ))
+                })
+                .unwrap_or(Value::Null),
+            CalendarPublishLinkProperty::Secret => Value::Null,
+        };
+        result.insert_unchecked(property.clone(), value);
+    }
+    Value::Object(result)
+}

--- a/crates/jmap/src/calendar_publish_link/get.rs
+++ b/crates/jmap/src/calendar_publish_link/get.rs
@@ -5,17 +5,16 @@
  */
 
 use common::Server;
-use groupware::calendar::publish_link::format_uuid;
+use groupware::calendar::publish_http::CalendarPublishStore;
 use jmap_proto::{
     method::get::{GetRequest, GetResponse},
     object::calendar_publish_link::{
         self, CalendarPublishLinkProperty, CalendarPublishLinkValue, PublishAccess,
         PublishVisibility,
     },
-    request::IntoValid,
+    request::{IntoValid, MaybeInvalid},
 };
 use jmap_tools::{Map, Value};
-use trc::AddContext;
 use types::id::Id;
 
 pub trait CalendarPublishLinkGet: Sync + Send {
@@ -43,15 +42,12 @@ impl CalendarPublishLinkGet for Server {
         ]);
 
         let account_id = request.account_id.document_id();
-        let filter_ids = request
-            .ids
-            .take()
-            .map(|ids| {
-                ids.unwrap()
-                    .into_valid()
-                    .map(|id| id.as_ref().to_string())
-                    .collect::<std::collections::HashSet<_>>()
-            });
+        let filter_ids = request.ids.take().map(|ids| {
+            ids.unwrap()
+                .into_valid()
+                .map(|id| id.document_id())
+                .collect::<std::collections::HashSet<_>>()
+        });
 
         let links = self.list_publish_links(account_id).await?;
         let mut response = GetResponse {
@@ -61,25 +57,27 @@ impl CalendarPublishLinkGet for Server {
             not_found: vec![],
         };
 
-        for link in links {
-            let id = format_uuid(&link.link_id);
-            if filter_ids.as_ref().is_some_and(|ids| !ids.contains(&id)) {
+        for link in &links {
+            if filter_ids
+                .as_ref()
+                .is_some_and(|ids| !ids.contains(&link.document_id))
+            {
                 continue;
             }
             if response.list.len() >= self.core.jmap.get_max_objects {
                 break;
             }
             response.list.push(build_publish_link_object(
-                &link,
+                link,
                 &properties,
-                self.build_publish_url(&link, None),
+                self.build_publish_url(link, None),
             ));
         }
 
         if let Some(ids) = filter_ids {
-            for id in ids {
-                if !links.iter().any(|l| format_uuid(&l.link_id) == id) {
-                    response.not_found.push(id);
+            for document_id in ids {
+                if !links.iter().any(|l| l.document_id == document_id) {
+                    response.not_found.push(MaybeInvalid::Value(Id::from(document_id)));
                 }
             }
         }
@@ -93,12 +91,11 @@ fn build_publish_link_object(
     properties: &[CalendarPublishLinkProperty],
     url: String,
 ) -> Value<'static, CalendarPublishLinkProperty, CalendarPublishLinkValue> {
-    let id = format_uuid(&link.link_id);
     let mut result = Map::with_capacity(properties.len());
     for property in properties {
         let value = match property {
             CalendarPublishLinkProperty::Id => {
-                Value::Element(CalendarPublishLinkValue::Id(id.clone()))
+                Value::Element(CalendarPublishLinkValue::Id(Id::from(link.document_id)))
             }
             CalendarPublishLinkProperty::CalendarId => Value::Element(
                 CalendarPublishLinkValue::CalendarId(Id::from(link.calendar_id)),

--- a/crates/jmap/src/calendar_publish_link/get.rs
+++ b/crates/jmap/src/calendar_publish_link/get.rs
@@ -4,23 +4,26 @@
  * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
  */
 
-use common::Server;
-use groupware::calendar::publish_http::CalendarPublishStore;
+use common::{Server, auth::AccessToken};
+use groupware::{cache::GroupwareCache, calendar::publish_http::CalendarPublishStore};
 use jmap_proto::{
     method::get::{GetRequest, GetResponse},
     object::calendar_publish_link::{
         self, CalendarPublishLinkProperty, CalendarPublishLinkValue, PublishAccess,
         PublishVisibility,
     },
-    request::{IntoValid, MaybeInvalid},
+    request::MaybeInvalid,
 };
 use jmap_tools::{Map, Value};
-use types::id::Id;
+use types::{collection::SyncCollection, id::Id};
+
+use super::set::assert_calendar_publish_acl;
 
 pub trait CalendarPublishLinkGet: Sync + Send {
     fn calendar_publish_link_get(
         &self,
         request: GetRequest<calendar_publish_link::CalendarPublishLink>,
+        access_token: &AccessToken,
     ) -> impl Future<Output = trc::Result<GetResponse<calendar_publish_link::CalendarPublishLink>>> + Send;
 }
 
@@ -28,6 +31,7 @@ impl CalendarPublishLinkGet for Server {
     async fn calendar_publish_link_get(
         &self,
         mut request: GetRequest<calendar_publish_link::CalendarPublishLink>,
+        access_token: &AccessToken,
     ) -> trc::Result<GetResponse<calendar_publish_link::CalendarPublishLink>> {
         let properties = request.unwrap_properties(&[
             CalendarPublishLinkProperty::Id,
@@ -41,44 +45,53 @@ impl CalendarPublishLinkGet for Server {
             CalendarPublishLinkProperty::ExpiresAt,
         ]);
 
+        let (ids, not_found_ids) = request.unwrap_ids(self.core.jmap.get_max_objects)?;
         let account_id = request.account_id.document_id();
-        let filter_ids = request.ids.take().map(|ids| {
-            ids.unwrap()
-                .into_valid()
-                .map(|id| id.document_id())
-                .collect::<std::collections::HashSet<_>>()
-        });
 
-        let links = self.list_publish_links(account_id).await?;
+        let cache = self
+            .fetch_dav_resources(
+                access_token.account_id(),
+                account_id,
+                SyncCollection::Calendar,
+            )
+            .await?;
+        let links: Vec<_> = self
+            .list_publish_links(account_id)
+            .await?
+            .into_iter()
+            .filter(|link| {
+                assert_calendar_publish_acl(access_token, account_id, link.calendar_id, &cache)
+                    .is_ok()
+            })
+            .collect();
+
+        let ids = if let Some(ids) = ids {
+            ids
+        } else {
+            links
+                .iter()
+                .take(self.core.jmap.get_max_objects)
+                .map(|link| Id::from(link.document_id))
+                .collect::<Vec<_>>()
+        };
+
         let mut response = GetResponse {
             account_id: request.account_id.into(),
             state: None,
-            list: Vec::new(),
-            not_found: vec![],
+            list: Vec::with_capacity(ids.len()),
+            not_found: not_found_ids,
         };
 
-        for link in &links {
-            if filter_ids
-                .as_ref()
-                .is_some_and(|ids| !ids.contains(&link.document_id))
-            {
-                continue;
-            }
-            if response.list.len() >= self.core.jmap.get_max_objects {
-                break;
-            }
-            response.list.push(build_publish_link_object(
-                link,
-                &properties,
-                self.build_publish_url(link, None),
-            ));
-        }
-
-        if let Some(ids) = filter_ids {
-            for document_id in ids {
-                if !links.iter().any(|l| l.document_id == document_id) {
-                    response.not_found.push(MaybeInvalid::Value(Id::from(document_id)));
-                }
+        for id in ids {
+            let document_id = id.document_id();
+            if let Some(link) = links.iter().find(|l| l.document_id == document_id) {
+                response.list.push(build_publish_link_object(
+                    link,
+                    &properties,
+                    self.build_publish_url(link, None),
+                ));
+            } else {
+                response.not_found.push(MaybeInvalid::Value(id));
             }
         }
 

--- a/crates/jmap/src/calendar_publish_link/mod.rs
+++ b/crates/jmap/src/calendar_publish_link/mod.rs
@@ -1,0 +1,2 @@
+pub mod get;
+pub mod set;

--- a/crates/jmap/src/calendar_publish_link/set.rs
+++ b/crates/jmap/src/calendar_publish_link/set.rs
@@ -9,22 +9,26 @@ use groupware::{
     cache::GroupwareCache,
     calendar::publish_link::{
         CalendarPublishLink, MAX_PRIVATE_LINKS_PER_CALENDAR, MAX_PUBLIC_LINKS_PER_CALENDAR,
-        PublishAccess, PublishVisibility, format_uuid, parse_uuid,
+        PublishAccess, PublishVisibility,
     },
-    calendar::publish_http::create_publish_link_secret,
+    calendar::publish_http::{CalendarPublishStore, clear_publish_link, create_publish_link_secret},
 };
 use jmap_proto::{
     error::set::SetError,
     method::set::{SetRequest, SetResponse},
-    object::calendar_publish_link::{
-        self, CalendarPublishLinkProperty, CalendarPublishLinkValue, PublishAccess as JmapAccess,
-        PublishVisibility as JmapVisibility,
+    object::{
+        JmapObjectId,
+        calendar_publish_link::{
+            self, CalendarPublishLinkProperty, CalendarPublishLinkValue, PublishAccess as JmapAccess,
+            PublishVisibility as JmapVisibility,
+        },
     },
+    request::MaybeInvalid,
 };
 use jmap_tools::{Key, Map, Value};
 use store::write::{BatchBuilder, now};
 use trc::AddContext;
-use types::{acl::Acl, collection::SyncCollection};
+use types::{acl::Acl, collection::SyncCollection, id::Id};
 use utils::map::bitmap::Bitmap;
 
 pub trait CalendarPublishLinkSet: Sync + Send {
@@ -44,6 +48,7 @@ impl CalendarPublishLinkSet for Server {
         let account_id = request.account_id.document_id();
         let mut response =
             SetResponse::from_request(&request, self.core.jmap.set_max_objects)?;
+        let will_destroy = response.collect_will_destroy(request.unwrap_destroy());
         let cache = self
             .fetch_dav_resources(
                 access_token.account_id(),
@@ -52,6 +57,12 @@ impl CalendarPublishLinkSet for Server {
             )
             .await?;
         let existing_links = self.list_publish_links(account_id).await?;
+        let mut next_document_id = existing_links
+            .iter()
+            .map(|l| l.document_id)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
         let mut batch = BatchBuilder::new();
 
         'create: for (id, object) in request.unwrap_create() {
@@ -63,13 +74,13 @@ impl CalendarPublishLinkSet for Server {
 
             for (property, value) in object.into_expanded_object() {
                 match property {
-                    CalendarPublishLinkProperty::CalendarId => {
+                    Key::Property(CalendarPublishLinkProperty::CalendarId) => {
                         calendar_id = value
                             .into_element()
                             .and_then(|e| e.as_id())
                             .map(|id| id.document_id());
                     }
-                    CalendarPublishLinkProperty::Access => {
+                    Key::Property(CalendarPublishLinkProperty::Access) => {
                         access = match value.into_element() {
                             Some(CalendarPublishLinkValue::Access(JmapAccess::Public)) => {
                                 PublishAccess::Public
@@ -77,7 +88,7 @@ impl CalendarPublishLinkSet for Server {
                             _ => PublishAccess::Private,
                         };
                     }
-                    CalendarPublishLinkProperty::Visibility => {
+                    Key::Property(CalendarPublishLinkProperty::Visibility) => {
                         visibility = match value.into_element() {
                             Some(CalendarPublishLinkValue::Visibility(JmapVisibility::Busy)) => {
                                 PublishVisibility::Busy
@@ -85,16 +96,16 @@ impl CalendarPublishLinkSet for Server {
                             _ => PublishVisibility::Full,
                         };
                     }
-                    CalendarPublishLinkProperty::Label => {
-                        label = value.into_string();
+                    Key::Property(CalendarPublishLinkProperty::Label) => {
+                        label = value.into_string().map(|s| s.into_owned());
                     }
-                    CalendarPublishLinkProperty::ExpiresAt => {
+                    Key::Property(CalendarPublishLinkProperty::ExpiresAt) => {
                         expires_at = value.into_element().and_then(|e| match e {
                             CalendarPublishLinkValue::Date(d) => Some(d.timestamp()),
                             _ => None,
                         });
                     }
-                    CalendarPublishLinkProperty::Secret => {
+                    Key::Property(CalendarPublishLinkProperty::Secret) => {
                         response.not_created.append(
                             id,
                             SetError::invalid_properties()
@@ -174,7 +185,11 @@ impl CalendarPublishLinkSet for Server {
                 (None, None)
             };
 
+            let document_id = next_document_id;
+            next_document_id = next_document_id.saturating_add(1);
+
             let link = CalendarPublishLink::new(
+                document_id,
                 calendar_id,
                 access,
                 visibility,
@@ -188,7 +203,7 @@ impl CalendarPublishLinkSet for Server {
             let mut created = Map::with_capacity(4);
             created.insert_unchecked(
                 CalendarPublishLinkProperty::Id,
-                Value::Element(CalendarPublishLinkValue::Id(format_uuid(&link.link_id))),
+                Value::Element(CalendarPublishLinkValue::Id(Id::from(document_id))),
             );
             created.insert_unchecked(CalendarPublishLinkProperty::Url, Value::Str(url.into()));
             if let Some(secret) = secret_token {
@@ -201,20 +216,31 @@ impl CalendarPublishLinkSet for Server {
         }
 
         'update: for (id, object) in request.unwrap_update() {
-            let link_id = match parse_uuid(&id) {
-                Some(link_id) => link_id,
-                None => {
-                    response.not_updated.append(id, SetError::not_found());
+            let id = match id {
+                MaybeInvalid::Value(id) => id,
+                invalid => {
+                    response.not_updated.append(invalid, SetError::not_found());
                     continue 'update;
                 }
             };
-            let mut link = match self.get_publish_link(account_id, link_id).await? {
+            if will_destroy.contains(&id) {
+                response.not_updated.append(id, SetError::will_destroy());
+                continue 'update;
+            }
+
+            let document_id = id.document_id();
+            let mut link = match existing_links
+                .iter()
+                .find(|l| l.document_id == document_id)
+                .cloned()
+            {
                 Some(link) => link,
                 None => {
                     response.not_updated.append(id, SetError::not_found());
                     continue 'update;
                 }
             };
+
             if let Err(err) =
                 assert_calendar_publish_acl(access_token, account_id, link.calendar_id, &cache)
             {
@@ -224,7 +250,7 @@ impl CalendarPublishLinkSet for Server {
 
             for (property, value) in object.into_expanded_object() {
                 match property {
-                    CalendarPublishLinkProperty::Secret => {
+                    Key::Property(CalendarPublishLinkProperty::Secret) => {
                         response.not_updated.append(
                             id,
                             SetError::invalid_properties()
@@ -233,10 +259,10 @@ impl CalendarPublishLinkSet for Server {
                         );
                         continue 'update;
                     }
-                    CalendarPublishLinkProperty::Label => {
-                        link.label = value.into_string();
+                    Key::Property(CalendarPublishLinkProperty::Label) => {
+                        link.label = value.into_string().map(|s| s.into_owned());
                     }
-                    CalendarPublishLinkProperty::Visibility => {
+                    Key::Property(CalendarPublishLinkProperty::Visibility) => {
                         link.visibility = match value.into_element() {
                             Some(CalendarPublishLinkValue::Visibility(JmapVisibility::Busy)) => {
                                 PublishVisibility::Busy
@@ -244,7 +270,7 @@ impl CalendarPublishLinkSet for Server {
                             _ => PublishVisibility::Full,
                         };
                     }
-                    CalendarPublishLinkProperty::ExpiresAt => {
+                    Key::Property(CalendarPublishLinkProperty::ExpiresAt) => {
                         link.expires_at = value.into_element().and_then(|e| match e {
                             CalendarPublishLinkValue::Date(d) => Some(d.timestamp()),
                             _ => None,
@@ -254,18 +280,15 @@ impl CalendarPublishLinkSet for Server {
                 }
             }
             self.store_publish_link(&mut batch, account_id, &link)?;
-            response.updated.push(id);
+            response.updated.append(id, None);
         }
 
-        for id in request.unwrap_destroy() {
-            let link_id = match parse_uuid(&id) {
-                Some(link_id) => link_id,
-                None => {
-                    response.not_destroyed.append(id, SetError::not_found());
-                    continue;
-                }
-            };
-            if let Some(link) = self.get_publish_link(account_id, link_id).await? {
+        for id in will_destroy {
+            let document_id = id.document_id();
+            if let Some(link) = existing_links
+                .iter()
+                .find(|l| l.document_id == document_id)
+            {
                 if let Err(err) = assert_calendar_publish_acl(
                     access_token,
                     account_id,
@@ -275,7 +298,7 @@ impl CalendarPublishLinkSet for Server {
                     response.not_destroyed.append(id, err);
                     continue;
                 }
-                Self::clear_publish_link(&mut batch, account_id, link_id);
+                clear_publish_link(&mut batch, account_id, link.link_id);
                 response.destroyed.push(id);
             } else {
                 response.not_destroyed.append(id, SetError::not_found());
@@ -302,7 +325,7 @@ fn assert_calendar_publish_acl(
     if access_token.is_member(account_id) {
         return Ok(());
     }
-    let required = Bitmap::from_iter([Acl::ModifyItems, Acl::Administer]);
+    let required = Bitmap::from_iter([Acl::ModifyItems, Acl::Modify]);
     if cache.has_access_to_container(access_token, calendar_id, required) {
         Ok(())
     } else {

--- a/crates/jmap/src/calendar_publish_link/set.rs
+++ b/crates/jmap/src/calendar_publish_link/set.rs
@@ -28,7 +28,11 @@ use jmap_proto::{
 use jmap_tools::{Key, Map, Value};
 use store::write::{BatchBuilder, now};
 use trc::AddContext;
-use types::{acl::Acl, collection::SyncCollection, id::Id};
+use types::{
+    acl::Acl,
+    collection::{Collection, SyncCollection},
+    id::Id,
+};
 use utils::map::bitmap::Bitmap;
 
 pub trait CalendarPublishLinkSet: Sync + Send {
@@ -56,13 +60,7 @@ impl CalendarPublishLinkSet for Server {
                 SyncCollection::Calendar,
             )
             .await?;
-        let existing_links = self.list_publish_links(account_id).await?;
-        let mut next_document_id = existing_links
-            .iter()
-            .map(|l| l.document_id)
-            .max()
-            .unwrap_or(0)
-            .saturating_add(1);
+        let mut existing_links = self.list_publish_links(account_id).await?;
         let mut batch = BatchBuilder::new();
 
         'create: for (id, object) in request.unwrap_create() {
@@ -185,8 +183,11 @@ impl CalendarPublishLinkSet for Server {
                 (None, None)
             };
 
-            let document_id = next_document_id;
-            next_document_id = next_document_id.saturating_add(1);
+            let document_id = self
+                .store()
+                .assign_document_ids(account_id, Collection::None, 1)
+                .await
+                .caused_by(trc::location!())?;
 
             let link = CalendarPublishLink::new(
                 document_id,
@@ -199,6 +200,7 @@ impl CalendarPublishLinkSet for Server {
                 expires_at,
             );
             self.store_publish_link(&mut batch, account_id, &link)?;
+            existing_links.push(link.clone());
             let url = self.build_publish_url(&link, secret_token.as_deref());
             let mut created = Map::with_capacity(4);
             created.insert_unchecked(
@@ -313,7 +315,7 @@ impl CalendarPublishLinkSet for Server {
     }
 }
 
-fn assert_calendar_publish_acl(
+pub(crate) fn assert_calendar_publish_acl(
     access_token: &AccessToken,
     account_id: u32,
     calendar_id: u32,

--- a/crates/jmap/src/calendar_publish_link/set.rs
+++ b/crates/jmap/src/calendar_publish_link/set.rs
@@ -1,0 +1,313 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+use common::{Server, auth::AccessToken};
+use groupware::{
+    cache::GroupwareCache,
+    calendar::publish_link::{
+        CalendarPublishLink, MAX_PRIVATE_LINKS_PER_CALENDAR, MAX_PUBLIC_LINKS_PER_CALENDAR,
+        PublishAccess, PublishVisibility, format_uuid, parse_uuid,
+    },
+    calendar::publish_http::create_publish_link_secret,
+};
+use jmap_proto::{
+    error::set::SetError,
+    method::set::{SetRequest, SetResponse},
+    object::calendar_publish_link::{
+        self, CalendarPublishLinkProperty, CalendarPublishLinkValue, PublishAccess as JmapAccess,
+        PublishVisibility as JmapVisibility,
+    },
+};
+use jmap_tools::{Key, Map, Value};
+use store::write::{BatchBuilder, now};
+use trc::AddContext;
+use types::{acl::Acl, collection::SyncCollection};
+use utils::map::bitmap::Bitmap;
+
+pub trait CalendarPublishLinkSet: Sync + Send {
+    fn calendar_publish_link_set(
+        &self,
+        request: SetRequest<'_, calendar_publish_link::CalendarPublishLink>,
+        access_token: &AccessToken,
+    ) -> impl Future<Output = trc::Result<SetResponse<calendar_publish_link::CalendarPublishLink>>> + Send;
+}
+
+impl CalendarPublishLinkSet for Server {
+    async fn calendar_publish_link_set(
+        &self,
+        mut request: SetRequest<'_, calendar_publish_link::CalendarPublishLink>,
+        access_token: &AccessToken,
+    ) -> trc::Result<SetResponse<calendar_publish_link::CalendarPublishLink>> {
+        let account_id = request.account_id.document_id();
+        let mut response =
+            SetResponse::from_request(&request, self.core.jmap.set_max_objects)?;
+        let cache = self
+            .fetch_dav_resources(
+                access_token.account_id(),
+                account_id,
+                SyncCollection::Calendar,
+            )
+            .await?;
+        let existing_links = self.list_publish_links(account_id).await?;
+        let mut batch = BatchBuilder::new();
+
+        'create: for (id, object) in request.unwrap_create() {
+            let mut calendar_id = None;
+            let mut access = PublishAccess::Private;
+            let mut visibility = PublishVisibility::Full;
+            let mut label = None;
+            let mut expires_at = None;
+
+            for (property, value) in object.into_expanded_object() {
+                match property {
+                    CalendarPublishLinkProperty::CalendarId => {
+                        calendar_id = value
+                            .into_element()
+                            .and_then(|e| e.as_id())
+                            .map(|id| id.document_id());
+                    }
+                    CalendarPublishLinkProperty::Access => {
+                        access = match value.into_element() {
+                            Some(CalendarPublishLinkValue::Access(JmapAccess::Public)) => {
+                                PublishAccess::Public
+                            }
+                            _ => PublishAccess::Private,
+                        };
+                    }
+                    CalendarPublishLinkProperty::Visibility => {
+                        visibility = match value.into_element() {
+                            Some(CalendarPublishLinkValue::Visibility(JmapVisibility::Busy)) => {
+                                PublishVisibility::Busy
+                            }
+                            _ => PublishVisibility::Full,
+                        };
+                    }
+                    CalendarPublishLinkProperty::Label => {
+                        label = value.into_string();
+                    }
+                    CalendarPublishLinkProperty::ExpiresAt => {
+                        expires_at = value.into_element().and_then(|e| match e {
+                            CalendarPublishLinkValue::Date(d) => Some(d.timestamp()),
+                            _ => None,
+                        });
+                    }
+                    CalendarPublishLinkProperty::Secret => {
+                        response.not_created.append(
+                            id,
+                            SetError::invalid_properties()
+                                .with_property(CalendarPublishLinkProperty::Secret)
+                                .with_description("Secret cannot be set on create."),
+                        );
+                        continue 'create;
+                    }
+                    _ => {}
+                }
+            }
+
+            let Some(calendar_id) = calendar_id else {
+                response.not_created.append(
+                    id,
+                    SetError::invalid_properties()
+                        .with_property(CalendarPublishLinkProperty::CalendarId),
+                );
+                continue 'create;
+            };
+
+            if let Err(err) =
+                assert_calendar_publish_acl(access_token, account_id, calendar_id, &cache)
+            {
+                response.not_created.append(id, err);
+                continue 'create;
+            }
+
+            let calendar_links: Vec<_> = existing_links
+                .iter()
+                .filter(|l| l.calendar_id == calendar_id)
+                .collect();
+            let private_count = calendar_links
+                .iter()
+                .filter(|l| l.access == PublishAccess::Private)
+                .count();
+            let public_count = calendar_links
+                .iter()
+                .filter(|l| l.access == PublishAccess::Public)
+                .count();
+
+            if access == PublishAccess::Private && private_count >= MAX_PRIVATE_LINKS_PER_CALENDAR
+            {
+                response.not_created.append(
+                    id,
+                    SetError::forbidden()
+                        .with_description("Maximum private publish links reached for calendar."),
+                );
+                continue 'create;
+            }
+            if access == PublishAccess::Public {
+                if public_count >= MAX_PUBLIC_LINKS_PER_CALENDAR {
+                    response.not_created.append(
+                        id,
+                        SetError::forbidden()
+                            .with_description("Maximum public publish links reached for calendar."),
+                    );
+                    continue 'create;
+                }
+                if calendar_links
+                    .iter()
+                    .any(|l| l.access == PublishAccess::Public && l.visibility == visibility)
+                {
+                    response.not_created.append(
+                        id,
+                        SetError::forbidden()
+                            .with_description("A public link with this visibility already exists."),
+                    );
+                    continue 'create;
+                }
+            }
+
+            let (secret_token, secret_hash) = if access == PublishAccess::Private {
+                let (secret, hash) = create_publish_link_secret().await;
+                (Some(secret.build()), Some(hash))
+            } else {
+                (None, None)
+            };
+
+            let link = CalendarPublishLink::new(
+                calendar_id,
+                access,
+                visibility,
+                label,
+                secret_hash,
+                now() as i64,
+                expires_at,
+            );
+            self.store_publish_link(&mut batch, account_id, &link)?;
+            let url = self.build_publish_url(&link, secret_token.as_deref());
+            let mut created = Map::with_capacity(4);
+            created.insert_unchecked(
+                CalendarPublishLinkProperty::Id,
+                Value::Element(CalendarPublishLinkValue::Id(format_uuid(&link.link_id))),
+            );
+            created.insert_unchecked(CalendarPublishLinkProperty::Url, Value::Str(url.into()));
+            if let Some(secret) = secret_token {
+                created.insert_unchecked(
+                    CalendarPublishLinkProperty::Secret,
+                    Value::Str(secret.into()),
+                );
+            }
+            response.created.insert(id, Value::Object(created));
+        }
+
+        'update: for (id, object) in request.unwrap_update() {
+            let link_id = match parse_uuid(&id) {
+                Some(link_id) => link_id,
+                None => {
+                    response.not_updated.append(id, SetError::not_found());
+                    continue 'update;
+                }
+            };
+            let mut link = match self.get_publish_link(account_id, link_id).await? {
+                Some(link) => link,
+                None => {
+                    response.not_updated.append(id, SetError::not_found());
+                    continue 'update;
+                }
+            };
+            if let Err(err) =
+                assert_calendar_publish_acl(access_token, account_id, link.calendar_id, &cache)
+            {
+                response.not_updated.append(id, err);
+                continue 'update;
+            }
+
+            for (property, value) in object.into_expanded_object() {
+                match property {
+                    CalendarPublishLinkProperty::Secret => {
+                        response.not_updated.append(
+                            id,
+                            SetError::invalid_properties()
+                                .with_property(CalendarPublishLinkProperty::Secret)
+                                .with_description("Secret cannot be updated."),
+                        );
+                        continue 'update;
+                    }
+                    CalendarPublishLinkProperty::Label => {
+                        link.label = value.into_string();
+                    }
+                    CalendarPublishLinkProperty::Visibility => {
+                        link.visibility = match value.into_element() {
+                            Some(CalendarPublishLinkValue::Visibility(JmapVisibility::Busy)) => {
+                                PublishVisibility::Busy
+                            }
+                            _ => PublishVisibility::Full,
+                        };
+                    }
+                    CalendarPublishLinkProperty::ExpiresAt => {
+                        link.expires_at = value.into_element().and_then(|e| match e {
+                            CalendarPublishLinkValue::Date(d) => Some(d.timestamp()),
+                            _ => None,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            self.store_publish_link(&mut batch, account_id, &link)?;
+            response.updated.push(id);
+        }
+
+        for id in request.unwrap_destroy() {
+            let link_id = match parse_uuid(&id) {
+                Some(link_id) => link_id,
+                None => {
+                    response.not_destroyed.append(id, SetError::not_found());
+                    continue;
+                }
+            };
+            if let Some(link) = self.get_publish_link(account_id, link_id).await? {
+                if let Err(err) = assert_calendar_publish_acl(
+                    access_token,
+                    account_id,
+                    link.calendar_id,
+                    &cache,
+                ) {
+                    response.not_destroyed.append(id, err);
+                    continue;
+                }
+                Self::clear_publish_link(&mut batch, account_id, link_id);
+                response.destroyed.push(id);
+            } else {
+                response.not_destroyed.append(id, SetError::not_found());
+            }
+        }
+
+        if !batch.is_empty() {
+            self.commit_batch(batch).await.caused_by(trc::location!())?;
+        }
+
+        Ok(response)
+    }
+}
+
+fn assert_calendar_publish_acl(
+    access_token: &AccessToken,
+    account_id: u32,
+    calendar_id: u32,
+    cache: &common::DavResources,
+) -> Result<(), SetError<CalendarPublishLinkProperty>> {
+    if !cache.has_container_id(&calendar_id) {
+        return Err(SetError::not_found());
+    }
+    if access_token.is_member(account_id) {
+        return Ok(());
+    }
+    let required = Bitmap::from_iter([Acl::ModifyItems, Acl::Administer]);
+    if cache.has_access_to_container(access_token, calendar_id, required) {
+        Ok(())
+    } else {
+        Err(SetError::forbidden().with_description(
+            "Write or admin access to the calendar is required.",
+        ))
+    }
+}

--- a/crates/jmap/src/calendar_publish_link/set.rs
+++ b/crates/jmap/src/calendar_publish_link/set.rs
@@ -327,12 +327,14 @@ pub(crate) fn assert_calendar_publish_acl(
     if access_token.is_member(account_id) {
         return Ok(());
     }
-    let required = Bitmap::from_iter([Acl::ModifyItems, Acl::Modify]);
+    // Publishing an unauthenticated subscribe URL is a sharing act (same
+    // family as shareWith), not a write act — ModifyItems alone must not mint feeds.
+    let required = Bitmap::from_iter([Acl::Share]);
     if cache.has_access_to_container(access_token, calendar_id, required) {
         Ok(())
     } else {
         Err(SetError::forbidden().with_description(
-            "Write or admin access to the calendar is required.",
+            "Share access to the calendar is required to manage publish links.",
         ))
     }
 }

--- a/crates/jmap/src/changes/get.rs
+++ b/crates/jmap/src/changes/get.rs
@@ -405,6 +405,7 @@ impl IntermediateChangesResponse {
                 ChangesResponseMethod::ShareNotification(transmute_response(self.response))
             }
             MethodObject::ParticipantIdentity
+            | MethodObject::CalendarPublishLink
             | MethodObject::Core
             | MethodObject::Blob
             | MethodObject::PushSubscription

--- a/crates/jmap/src/lib.rs
+++ b/crates/jmap/src/lib.rs
@@ -28,6 +28,7 @@ pub mod blob;
 pub mod calendar;
 pub mod calendar_event;
 pub mod calendar_event_notification;
+pub mod calendar_publish_link;
 pub mod changes;
 pub mod contact;
 pub mod email;

--- a/crates/store/src/backend/foundationdb/write.rs
+++ b/crates/store/src/backend/foundationdb/write.rs
@@ -177,12 +177,15 @@ impl FdbStore {
                                         | SUBSPACE_TELEMETRY_SPAN
                                         | SUBSPACE_SEARCH_INDEX
                                         | SUBSPACE_LOGS
+                                        | SUBSPACE_PUBLISH_LINK
                                 ) && matches!(
                                     class,
                                     ValueClass::Property(_)
                                         | ValueClass::Queue(_)
                                         | ValueClass::Registry(RegistryClass::Item { .. })
                                         | ValueClass::ShareNotification { .. }
+                                        | ValueClass::CalendarPublishLink { .. }
+                                        | ValueClass::CalendarPublishLinkLookup { .. }
                                         | ValueClass::Telemetry(TelemetryClass::Metric { .. })
                                         | ValueClass::TaskQueue(TaskQueueClass::Task { .. })
                                         | ValueClass::InMemory(_)

--- a/crates/store/src/backend/mysql/main.rs
+++ b/crates/store/src/backend/mysql/main.rs
@@ -89,6 +89,7 @@ impl MysqlStore {
             SUBSPACE_TASK_QUEUE,
             SUBSPACE_DELETED_ITEMS,
             SUBSPACE_SPAM_SAMPLES,
+            SUBSPACE_PUBLISH_LINK,
             SUBSPACE_BLOB_LINK,
             SUBSPACE_IN_MEMORY_VALUE,
             SUBSPACE_PROPERTY,

--- a/crates/store/src/backend/postgres/main.rs
+++ b/crates/store/src/backend/postgres/main.rs
@@ -103,6 +103,7 @@ impl PostgresStore {
             SUBSPACE_TASK_QUEUE,
             SUBSPACE_DELETED_ITEMS,
             SUBSPACE_SPAM_SAMPLES,
+            SUBSPACE_PUBLISH_LINK,
             SUBSPACE_BLOB_LINK,
             SUBSPACE_IN_MEMORY_VALUE,
             SUBSPACE_PROPERTY,

--- a/crates/store/src/backend/rocksdb/main.rs
+++ b/crates/store/src/backend/rocksdb/main.rs
@@ -94,6 +94,7 @@ impl RocksDbStore {
             (SUBSPACE_TELEMETRY_METRIC, CfProfile::Scan),
             (SUBSPACE_SEARCH_INDEX, CfProfile::Scan),
             (SUBSPACE_SPAM_SAMPLES, CfProfile::Churn),
+            (SUBSPACE_PUBLISH_LINK, CfProfile::PointLookup),
             (SUBSPACE_REGISTRY_IDX, CfProfile::Scan),
             (SUBSPACE_REGISTRY_PK, CfProfile::PointLookup),
             (SUBSPACE_DIRECTORY, CfProfile::PointLookup),

--- a/crates/store/src/backend/sqlite/main.rs
+++ b/crates/store/src/backend/sqlite/main.rs
@@ -66,6 +66,7 @@ impl SqliteStore {
             SUBSPACE_TASK_QUEUE,
             SUBSPACE_DELETED_ITEMS,
             SUBSPACE_SPAM_SAMPLES,
+            SUBSPACE_PUBLISH_LINK,
             SUBSPACE_BLOB_LINK,
             SUBSPACE_IN_MEMORY_VALUE,
             SUBSPACE_PROPERTY,

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -124,6 +124,7 @@ pub const SUBSPACE_TELEMETRY_METRIC: u8 = b'x';
 pub const SUBSPACE_SEARCH_INDEX: u8 = b'z';
 pub const SUBSPACE_DELETED_ITEMS: u8 = b'j';
 pub const SUBSPACE_SPAM_SAMPLES: u8 = b'w';
+pub const SUBSPACE_PUBLISH_LINK: u8 = b'v';
 
 // TODO: Remove in v1.0
 pub const LEGACY_SUBSPACE_BITMAP_TEXT: u8 = b'v';

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -124,7 +124,7 @@ pub const SUBSPACE_TELEMETRY_METRIC: u8 = b'x';
 pub const SUBSPACE_SEARCH_INDEX: u8 = b'z';
 pub const SUBSPACE_DELETED_ITEMS: u8 = b'j';
 pub const SUBSPACE_SPAM_SAMPLES: u8 = b'w';
-pub const SUBSPACE_PUBLISH_LINK: u8 = b'v';
+pub const SUBSPACE_PUBLISH_LINK: u8 = b'V';
 
 // TODO: Remove in v1.0
 pub const LEGACY_SUBSPACE_BITMAP_TEXT: u8 = b'v';

--- a/crates/store/src/write/key.rs
+++ b/crates/store/src/write/key.rs
@@ -367,6 +367,12 @@ impl ValueClass {
                 account_id,
             } => serializer.write(*account_id).write(link_id.as_slice()),
             ValueClass::CalendarPublishLinkLookup { link_id } => {
+                // Single-byte prefix → 17-byte keys. CalendarPublishLink keys are
+                // always 20 bytes (u32 account_id + uuid), so these never collide —
+                // including when account_id is u32::MAX (JMAP id `d333333`, the
+                // calendars primary account). Do NOT use u32::MAX as a 4-byte prefix:
+                // that made lookup keys identical to CalendarPublishLink keys for
+                // that account and overwrote the archived link with the u32 account id.
                 serializer.write(0u8).write(link_id.as_slice())
             }
             ValueClass::SearchIndex(index) => match &index.typ {

--- a/crates/store/src/write/key.rs
+++ b/crates/store/src/write/key.rs
@@ -13,7 +13,7 @@ use crate::{
     SUBSPACE_IN_MEMORY_VALUE, SUBSPACE_INDEXES, SUBSPACE_LOGS, SUBSPACE_PROPERTY,
     SUBSPACE_QUEUE_EVENT, SUBSPACE_QUEUE_MESSAGE, SUBSPACE_QUOTA, SUBSPACE_REGISTRY,
     SUBSPACE_REGISTRY_IDX, SUBSPACE_REGISTRY_PK, SUBSPACE_REPORT_IN, SUBSPACE_REPORT_OUT,
-    SUBSPACE_SEARCH_INDEX, SUBSPACE_SPAM_SAMPLES, SUBSPACE_TASK_QUEUE, SUBSPACE_TELEMETRY_METRIC,
+    SUBSPACE_SEARCH_INDEX, SUBSPACE_SPAM_SAMPLES, SUBSPACE_PUBLISH_LINK, SUBSPACE_TASK_QUEUE, SUBSPACE_TELEMETRY_METRIC,
     SUBSPACE_TELEMETRY_SPAN, U16_LEN, U32_LEN, U64_LEN, ValueKey, WITH_SUBSPACE,
     write::{
         BlobLink, IndexPropertyClass, RegistryClass, SearchIndex, SearchIndexId, SearchIndexType,
@@ -362,6 +362,13 @@ impl ValueClass {
                 .write(*notify_account_id)
                 .write(u8::from(SyncCollection::ShareNotification))
                 .write(*notification_id),
+            ValueClass::CalendarPublishLink {
+                link_id,
+                account_id,
+            } => serializer.write(*account_id).write(link_id.as_slice()),
+            ValueClass::CalendarPublishLinkLookup { link_id } => {
+                serializer.write(0u8).write(link_id.as_slice())
+            }
             ValueClass::SearchIndex(index) => match &index.typ {
                 SearchIndexType::Term { field, hash } => {
                     let class = index.index.as_u8();
@@ -525,6 +532,8 @@ impl ValueClass {
             ValueClass::DocumentId | ValueClass::Quota | ValueClass::TenantQuota(_) => U32_LEN + 1,
             ValueClass::ChangeId => U32_LEN,
             ValueClass::ShareNotification { .. } => U32_LEN + U64_LEN + 1,
+            ValueClass::CalendarPublishLink { .. } => U32_LEN + 16,
+            ValueClass::CalendarPublishLinkLookup { .. } => 1 + 16,
             ValueClass::NodeId(_) => (U16_LEN * 3) + 1,
             ValueClass::SearchIndex(v) => match &v.typ {
                 SearchIndexType::Term { hash, .. } => U64_LEN + hash.len() + 2,
@@ -594,6 +603,9 @@ impl ValueClass {
             | ValueClass::Quota
             | ValueClass::TenantQuota(_) => SUBSPACE_COUNTER,
             ValueClass::ShareNotification { .. } => SUBSPACE_LOGS,
+            ValueClass::CalendarPublishLink { .. } | ValueClass::CalendarPublishLinkLookup { .. } => {
+                SUBSPACE_PUBLISH_LINK
+            }
             ValueClass::SearchIndex(_) => SUBSPACE_SEARCH_INDEX,
             ValueClass::Any(any) => any.subspace,
         }

--- a/crates/store/src/write/mod.rs
+++ b/crates/store/src/write/mod.rs
@@ -179,6 +179,13 @@ pub enum ValueClass {
         notification_id: u64,
         notify_account_id: u32,
     },
+    CalendarPublishLink {
+        link_id: [u8; 16],
+        account_id: u32,
+    },
+    CalendarPublishLinkLookup {
+        link_id: [u8; 16],
+    },
     DocumentId,
     ChangeId,
     Quota,

--- a/tests/src/jmap/calendar/mod.rs
+++ b/tests/src/jmap/calendar/mod.rs
@@ -10,3 +10,4 @@ pub mod calendars;
 pub mod event;
 pub mod identity;
 pub mod notification;
+pub mod publish_link;

--- a/tests/src/jmap/calendar/publish_link.rs
+++ b/tests/src/jmap/calendar/publish_link.rs
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+ */
+
+//! Calendar publish link JMAP and ICS export tests.
+
+// Integration tests for CalendarPublishLink/get, set, and /ics/* feeds are added
+// alongside the calendar ACL suite once CI can run the full JMAP test harness.


### PR DESCRIPTION
## Summary

Implements read-only calendar sharing via secret/public iCal subscribe URLs.

**Upstream request:** https://github.com/stalwartlabs/stalwart/issues/1644

- New JMAP type `CalendarPublishLink` (create / get / set / destroy)
- Unauthenticated HTTP feeds:
  - `/ics/{linkId}/{secret}.ics` (private)
  - `/ics/public/{linkId}.ics` (public)
- Visibility: `full` (with `CLASS:PRIVATE` redaction) and `busy`
- Per-calendar limits; **Share** ACL required to manage links
- Feed URLs from `STALWART_PUBLIC_URL` when set
- Embedded `VTIMEZONE` preserved when merging events into the feed

**Companion Bulwark UI:** (link PR once opened)

Closes https://github.com/stalwartlabs/stalwart/issues/1644

## Test plan

Verified locally against fork images (`cib-stalwart-ical:local` + Caddy `/ics` proxy):

- [x] `CalendarPublishLink/set` create private + public links; get returns `url` (`mail/scripts/ical-e2e.sh`)
- [x] Fetch private `/ics/{id}/{secret}.ics` without auth → 200 ICS
- [x] Wrong secret / revoked link → 404
- [x] Public link respects visibility (`busy` strips details)
- [x] `CLASS:PRIVATE` events redacted on `full` feeds
- [x] Non-member without Share ACL cannot create links (server ACL + UI `mayShare` gate)
- [x] IANA (`Australia/Sydney`) + embedded VTIMEZONE events in feed after `copy_timezones` fix
- [ ] Upstream CI / review on current `main` (branch diverged; rebase as needed)